### PR TITLE
Enhance catalog and add reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,24 @@
    ```bash
    pip install -r requirements.txt
    ```
-2. Запустите приложение:
+2. При необходимости укажите строку подключения к БД через переменную `DATABASE_URL`.
+   Пример для PostgreSQL:
+   `postgresql://user:password@localhost/airservice`.
+3. Запустите приложение:
    ```bash
    python run.py
    ```
 
 ## Использование
 
-- Получить каталог: `GET /catalog` с поддержкой фильтров `category`, `price_min`, `price_max`, `available` и поиска `q`
+- Получить каталог: `GET /catalog` с поддержкой фильтров `category`, `price_min`, `price_max`, `available`, `service` и поиска `q`
 - Создать заказ: `POST /orders` c JSON `{"seat": "12A", "items": [{"item_id": 1, "quantity": 2}]}`
 - Получить заказ: `GET /orders/<id>`
 - Админ-операции требуют basic-auth (`admin`/`admin`):
   - Список заказов: `GET /admin/orders`
   - Обновить статус: `PATCH /admin/orders/<id>` с JSON `{"status": "done"}`
   - CRUD товаров и категорий через `/admin/items` и `/admin/categories`
+  - Отчёт о продажах: `GET /admin/reports/sales?year=2025`
 - Swagger-документация доступна на `/apidocs/`
 
-Данные хранятся в SQLite-файле `airservice.db` в корне проекта.
+Данные по умолчанию хранятся в SQLite-файле `airservice.db`. Чтобы использовать PostgreSQL, задайте `DATABASE_URL`.

--- a/airservice/models.py
+++ b/airservice/models.py
@@ -21,6 +21,7 @@ class Item(db.Model):
     description = db.Column(db.Text)
     price = db.Column(db.Float, nullable=False)
     available = db.Column(db.Boolean, default=True)
+    is_service = db.Column(db.Boolean, default=False)
     category_id = db.Column(db.Integer, db.ForeignKey('category.id'))
     category = db.relationship('Category')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Werkzeug
 Flask-Limiter
 Flask-Babel
 Flasgger
+psycopg2-binary


### PR DESCRIPTION
## Summary
- support PostgreSQL through `DATABASE_URL`
- mark items as goods or services
- expose sales report API
- document new options
- include psycopg2 driver

## Testing
- `python -m py_compile airservice/app.py airservice/models.py run.py`
- ran server and exercised catalog, order and report endpoints

------
https://chatgpt.com/codex/tasks/task_e_6844ae6f990c83318d61844eb66ebee1