### PR TITLE
Introduce config classes for app

### DIFF
--- a/airservice/__init__.py
+++ b/airservice/__init__.py
@@ -1,2 +1,4 @@
 from .app import create_app
-__all__ = ['create_app']
+from .config import BaseConfig, DevConfig, TestConfig
+
+__all__ = ['create_app', 'BaseConfig', 'DevConfig', 'TestConfig']

--- a/airservice/config.py
+++ b/airservice/config.py
@@ -1,0 +1,22 @@
+import os
+from werkzeug.security import generate_password_hash
+
+
+class BaseConfig:
+    """Common configuration loading values from environment variables."""
+
+    def __init__(self):
+        self.SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///airservice.db")
+        self.SQLALCHEMY_TRACK_MODIFICATIONS = False
+        self.ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "admin")
+        self.ADMIN_PASSWORD_HASH = generate_password_hash(os.getenv("ADMIN_PASSWORD", "admin"))
+        self.BABEL_DEFAULT_LOCALE = os.getenv("BABEL_DEFAULT_LOCALE", "ru")
+
+
+class DevConfig(BaseConfig):
+    DEBUG = True
+
+
+class TestConfig(BaseConfig):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///:memory:")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from airservice.app import create_app
+from airservice.config import TestConfig
 from airservice.models import db, Category, Item, Order, OrderItem
 
 
@@ -20,11 +21,15 @@ def auth_header():
 @pytest.fixture
 def app():
     os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-    app = create_app({'TESTING': True})
+    os.environ['ADMIN_USERNAME'] = 'admin'
+    os.environ['ADMIN_PASSWORD'] = 'admin'
+    app = create_app(TestConfig)
     with app.app_context():
         db.create_all()
     yield app
     os.environ.pop('DATABASE_URL', None)
+    os.environ.pop('ADMIN_USERNAME', None)
+    os.environ.pop('ADMIN_PASSWORD', None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add `BaseConfig`, `DevConfig` and `TestConfig`
- refactor `create_app` to load config classes
- expose configuration classes from package
- update tests to use the new `TestConfig`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d08f291483319a4ece7af084ad95