### PR TITLE
Update admin credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 2. При необходимости укажите строку подключения к БД через переменную `DATABASE_URL`.
    Пример для PostgreSQL:
    `postgresql://user:password@localhost/airservice`.
-3. Запустите приложение (можно указать `SSL_CERT` и `SSL_KEY` для HTTPS):
+3. Вы можете задать логин администратора через `ADMIN_USERNAME` и пароль
+   через `ADMIN_PASSWORD` или готовый `ADMIN_PASSWORD_HASH`.
+   По умолчанию используются значения `admin`/`admin`.
+4. Запустите приложение (можно указать `SSL_CERT` и `SSL_KEY` для HTTPS):
    ```bash
    python run.py
    ```
@@ -21,7 +24,8 @@
 - Получить каталог: `GET /catalog` с поддержкой фильтров `category`, `price_min`, `price_max`, `available`, `service`, поиска `q` и параметра `lang=ru|en` для локализации названий
 - Создать заказ: `POST /orders` c JSON `{"seat": "12A", "items": [{"item_id": 1, "quantity": 2}]}`
 - Получить заказ: `GET /orders/<id>`
-- Админ-операции требуют basic-auth (`admin`/`admin`):
+- Админ-операции требуют basic-auth (по умолчанию `admin`/`admin`,
+  задаётся через `ADMIN_USERNAME` и `ADMIN_PASSWORD`/`ADMIN_PASSWORD_HASH`):
   - Список заказов: `GET /admin/orders`
   - Обновить статус: `PATCH /admin/orders/<id>` с JSON `{"status": "done"}`
   - CRUD товаров и категорий через `/admin/items` и `/admin/categories`

--- a/airservice/config.py
+++ b/airservice/config.py
@@ -9,7 +9,10 @@ class BaseConfig:
         self.SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///airservice.db")
         self.SQLALCHEMY_TRACK_MODIFICATIONS = False
         self.ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "admin")
-        self.ADMIN_PASSWORD_HASH = generate_password_hash(os.getenv("ADMIN_PASSWORD", "admin"))
+        pwd_hash = os.getenv("ADMIN_PASSWORD_HASH")
+        if not pwd_hash:
+            pwd_hash = generate_password_hash(os.getenv("ADMIN_PASSWORD", "admin"))
+        self.ADMIN_PASSWORD_HASH = pwd_hash
         self.BABEL_DEFAULT_LOCALE = os.getenv("BABEL_DEFAULT_LOCALE", "ru")
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,14 +22,15 @@ def auth_header():
 def app():
     os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
     os.environ['ADMIN_USERNAME'] = 'admin'
-    os.environ['ADMIN_PASSWORD'] = 'admin'
+    from werkzeug.security import generate_password_hash
+    os.environ['ADMIN_PASSWORD_HASH'] = generate_password_hash('admin')
     app = create_app(TestConfig)
     with app.app_context():
         db.create_all()
     yield app
     os.environ.pop('DATABASE_URL', None)
     os.environ.pop('ADMIN_USERNAME', None)
-    os.environ.pop('ADMIN_PASSWORD', None)
+    os.environ.pop('ADMIN_PASSWORD_HASH', None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- allow setting admin password hash via `ADMIN_PASSWORD_HASH`
- adapt tests to use hashed password environment variable
- document admin credential variables in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d58920388331a218a81a197ea678