### PR TITLE
Add Flask-Migrate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@
 2. При необходимости укажите строку подключения к БД через переменную `DATABASE_URL`.
    Пример для PostgreSQL:
    `postgresql://user:password@localhost/airservice`.
-3. Вы можете задать логин администратора через `ADMIN_USERNAME` и пароль
+3. Выполните миграции (при первом запуске):
+   ```bash
+   flask db init      # один раз
+   flask db migrate -m "init"
+   flask db upgrade
+   ```
+4. Вы можете задать логин администратора через `ADMIN_USERNAME` и пароль
    через `ADMIN_PASSWORD` или готовый `ADMIN_PASSWORD_HASH`.
    По умолчанию используются значения `admin`/`admin`.
-4. Запустите приложение (можно указать `SSL_CERT` и `SSL_KEY` для HTTPS):
+5. Запустите приложение (можно указать `SSL_CERT` и `SSL_KEY` для HTTPS):
    ```bash
    python run.py
    ```

--- a/airservice/app.py
+++ b/airservice/app.py
@@ -4,6 +4,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_babel import Babel
 from flasgger import Swagger
+from flask_migrate import Migrate
 
 from .config import DevConfig
 from .models import db
@@ -33,9 +34,7 @@ def create_app(config_object=None):
     Swagger(app)
 
     db.init_app(app)
-
-    with app.app_context():
-        db.create_all()
+    Migrate(app, db)
 
     app.register_blueprint(catalog_bp)
     app.register_blueprint(orders_bp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask-Babel
 Flasgger
 psycopg2-binary
 marshmallow
+Flask-Migrate


### PR DESCRIPTION
## Summary
- support migrations using Flask-Migrate
- document migration commands in README
- create empty `migrations/` folder
- remove automatic table creation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d749443083319ff2d7c9c339113e