### PR TITLE
Add catalog categories hierarchy endpoint

### DIFF
--- a/airservice/api/catalog.py
+++ b/airservice/api/catalog.py
@@ -48,3 +48,18 @@ def catalog():
             'category': i.category.name if i.category else None,
         })
     return jsonify(data)
+
+
+@catalog_bp.route('/catalog/categories')
+def catalog_categories():
+    """Return category hierarchy with nested children."""
+    cats = Category.query.order_by(Category.id).all()
+    nodes = {c.id: {'id': c.id, 'name': c.name, 'children': []} for c in cats}
+    roots = []
+    for c in cats:
+        node = nodes[c.id]
+        if c.parent_id and c.parent_id in nodes:
+            nodes[c.parent_id]['children'].append(node)
+        else:
+            roots.append(node)
+    return jsonify(roots)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,13 +48,15 @@ def sample_data(app):
             'Accessories': Category(name='Accessories'),
             'Services': Category(name='Services'),
         }
+        # subcategory for hierarchy tests
+        cats['Alcohol'] = Category(name='Alcohol', parent=cats['Drinks'])
         db.session.add_all(cats.values())
         db.session.flush()
         items = [
             Item(name='Sandwich', price=5.0, category=cats['Food']),
             Item(name='Salad', price=7.0, category=cats['Food']),
             Item(name='Water', price=1.5, category=cats['Drinks']),
-            Item(name='Wine', price=8.0, category=cats['Drinks']),
+            Item(name='Wine', price=8.0, category=cats['Alcohol']),
             Item(name='Coffee', price=3.0, category=cats['Drinks']),
             Item(name='Blanket', price=15.0, category=cats['Accessories']),
             Item(name='Headphones', price=25.0, category=cats['Accessories']),

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -61,3 +61,16 @@ def test_catalog_price_and_service_filters(client, sample_data):
         'Blanket': 15.0,
         'Headphones': 25.0,
     }
+
+
+def test_catalog_categories_hierarchy(client, sample_data):
+    rv = client.get('/catalog/categories')
+    assert rv.status_code == 200
+    data = rv.get_json()
+    # root categories
+    root_names = {c['name'] for c in data}
+    assert 'Drinks' in root_names
+    assert 'Alcohol' not in root_names
+    drinks = next(c for c in data if c['name'] == 'Drinks')
+    child_names = {c['name'] for c in drinks['children']}
+    assert 'Alcohol' in child_names


### PR DESCRIPTION
## Summary
- expose `/catalog/categories` for nested category hierarchy
- add subcategory fixture data for tests
- test `/catalog/categories` returns hierarchy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845de7de8b88331a8dc48588e37eb0e