### PR TITLE
Add payment method support for orders

### DIFF
--- a/airservice/api/orders.py
+++ b/airservice/api/orders.py
@@ -17,8 +17,9 @@ def create_order():
         return jsonify({'error': gettext('Invalid payload'), 'details': err.messages}), 400
     seat = payload['seat']
     items = payload['items']
+    payment_method = payload.get('payment_method')
     idem_key = request.headers.get('Idempotency-Key')
-    order, created = order_service.create_order(seat, items, idempotency_key=idem_key)
+    order, created = order_service.create_order(seat, items, payment_method=payment_method, idempotency_key=idem_key)
     status_code = 201 if created else 200
     return jsonify({'order_id': order.id}), status_code
 

--- a/airservice/models.py
+++ b/airservice/models.py
@@ -34,6 +34,7 @@ class Order(db.Model):
     idempotency_key = db.Column(db.String(64), unique=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     status = db.Column(db.String(20), default='new')
+    payment_method = db.Column(db.String(20))
 
 
 class OrderItem(db.Model):

--- a/airservice/schemas.py
+++ b/airservice/schemas.py
@@ -7,6 +7,7 @@ class OrderItemSchema(Schema):
 class OrderSchema(Schema):
     seat = fields.Str(required=True)
     items = fields.List(fields.Nested(OrderItemSchema), required=True)
+    payment_method = fields.Str()
 
 class ItemSchema(Schema):
     name = fields.Str(required=True)

--- a/airservice/services/order_service.py
+++ b/airservice/services/order_service.py
@@ -5,7 +5,7 @@ from ..models import db, Item, Order, OrderItem
 from ..events import push_event
 
 
-def create_order(seat: str, items: List[dict], idempotency_key: str | None = None) -> Tuple[Order, bool]:
+def create_order(seat: str, items: List[dict], *, payment_method: str | None = None, idempotency_key: str | None = None) -> Tuple[Order, bool]:
     """Create a new order with given items.
 
     Returns a tuple of (order, created) where created=False means an order with
@@ -15,7 +15,7 @@ def create_order(seat: str, items: List[dict], idempotency_key: str | None = Non
         existing = Order.query.filter_by(idempotency_key=idempotency_key).first()
         if existing:
             return existing, False
-    order = Order(seat=seat, idempotency_key=idempotency_key)
+    order = Order(seat=seat, idempotency_key=idempotency_key, payment_method=payment_method)
     db.session.add(order)
     db.session.commit()
     for it in items:

--- a/migrations/versions/001_add_payment_method_to_order.py
+++ b/migrations/versions/001_add_payment_method_to_order.py
@@ -1,0 +1,23 @@
+"""Add payment_method column to order
+
+Revision ID: 001
+Revises: None
+Create Date: 2024-04-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('order', sa.Column('payment_method', sa.String(length=20), nullable=True))
+
+
+def downgrade():
+    op.drop_column('order', 'payment_method')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,8 @@ def populate_orders(app, sample_data):
                     order = Order(
                         seat=f'{month}{num}A',
                         status='done',
-                        created_at=datetime(year, month, 15)
+                        created_at=datetime(year, month, 15),
+                        payment_method='card'
                     )
                     db.session.add(order)
                     db.session.flush()

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -5,7 +5,8 @@ def test_order_flow_and_idempotency(client, sample_data):
     item_id = sample_data['items']['Sandwich']
     payload = {
         'seat': '10B',
-        'items': [{'item_id': item_id, 'quantity': 2}]
+        'items': [{'item_id': item_id, 'quantity': 2}],
+        'payment_method': 'card'
     }
     rv = client.post('/orders', json=payload, headers={'Idempotency-Key': '123'})
     assert rv.status_code == 201
@@ -34,7 +35,7 @@ def test_create_order_invalid_payload(client):
 
 def test_update_order_status_validation(client, sample_data):
     item_id = sample_data['items']['Sandwich']
-    rv = client.post('/orders', json={'seat': '15C', 'items': [{'item_id': item_id}]})
+    rv = client.post('/orders', json={'seat': '15C', 'items': [{'item_id': item_id}], 'payment_method': 'cash'})
     assert rv.status_code == 201
     order_id = rv.get_json()['order_id']
     rv = client.patch(f'/admin/orders/{order_id}', json={'status': 'forming'}, headers=auth_header())

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,10 +9,11 @@ def test_order_service_create_and_idempotent(app, sample_data):
     items = [{'item_id': item_id, 'quantity': 1}]
     with app.app_context():
         with patch('airservice.services.order_service.push_event') as pe:
-            order, created = order_service.create_order('1A', items, idempotency_key='key1')
+            order, created = order_service.create_order('1A', items, payment_method='card', idempotency_key='key1')
             assert created
             pe.assert_called_with({'type': 'order_created', 'order_id': order.id})
-            order2, created2 = order_service.create_order('1A', items, idempotency_key='key1')
+            assert order.payment_method == 'card'
+            order2, created2 = order_service.create_order('1A', items, payment_method='card', idempotency_key='key1')
             assert not created2
             assert order.id == order2.id
 
@@ -20,7 +21,7 @@ def test_order_service_create_and_idempotent(app, sample_data):
 def test_update_order_status(app, sample_data):
     item_id = sample_data['items']['Sandwich']
     with app.app_context():
-        order, _ = order_service.create_order('2A', [{'item_id': item_id}], idempotency_key=None)
+        order, _ = order_service.create_order('2A', [{'item_id': item_id}], payment_method='cash', idempotency_key=None)
         with patch('airservice.services.order_service.push_event') as pe:
             updated = order_service.update_order_status(order.id, 'done')
             assert updated.status == 'done'


### PR DESCRIPTION
## Summary
- add `payment_method` field to `Order` model
- update schema, service and API to handle payment method
- add Alembic migration
- adjust tests for new parameter

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845df8deb788331939739fad42e183b