### PR TITLE
Validate order item IDs

### DIFF
--- a/airservice/api/orders.py
+++ b/airservice/api/orders.py
@@ -55,7 +55,15 @@ def create_order():
     items = payload['items']
     payment_method = payload.get('payment_method')
     idem_key = request.headers.get('Idempotency-Key')
-    order, created = order_service.create_order(seat, items, payment_method=payment_method, idempotency_key=idem_key)
+    try:
+        order, created = order_service.create_order(
+            seat,
+            items,
+            payment_method=payment_method,
+            idempotency_key=idem_key,
+        )
+    except ValueError as err:
+        return jsonify({'error': str(err)}), 400
     status_code = 201 if created else 200
     return jsonify({'order_id': order.id}), status_code
 

--- a/airservice/services/order_service.py
+++ b/airservice/services/order_service.py
@@ -15,14 +15,26 @@ def create_order(seat: str, items: List[dict], *, payment_method: str | None = N
         existing = Order.query.filter_by(idempotency_key=idempotency_key).first()
         if existing:
             return existing, False
+
+    missing_ids = []
+    validated_items: list[tuple[Item, int]] = []
+    for it in items:
+        item_id = it.get("item_id")
+        item = db.session.get(Item, item_id)
+        if not item:
+            missing_ids.append(item_id)
+        else:
+            validated_items.append((item, it.get("quantity", 1)))
+    if missing_ids:
+        raise ValueError(f"Invalid item IDs: {missing_ids}")
+
     order = Order(seat=seat, idempotency_key=idempotency_key, payment_method=payment_method)
     db.session.add(order)
     db.session.commit()
-    for it in items:
-        item = db.session.get(Item, it.get("item_id"))
-        if item:
-            oi = OrderItem(order_id=order.id, item_id=item.id, quantity=it.get("quantity", 1))
-            db.session.add(oi)
+
+    for item, qty in validated_items:
+        oi = OrderItem(order_id=order.id, item_id=item.id, quantity=qty)
+        db.session.add(oi)
     db.session.commit()
     logging.info("order_created %s seat=%s", order.id, order.seat)
     push_event({"type": "order_created", "order_id": order.id})

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -33,6 +33,23 @@ def test_create_order_invalid_payload(client):
     assert rv.status_code == 400
 
 
+def test_create_order_rejects_invalid_items(client, sample_data):
+    bad_id = max(sample_data['items'].values()) + 1
+    payload = {'seat': '22A', 'items': [{'item_id': bad_id}]}
+    rv = client.post('/orders', json=payload)
+    assert rv.status_code == 400
+
+    payload = {
+        'seat': '22B',
+        'items': [
+            {'item_id': sample_data['items']['Sandwich']},
+            {'item_id': bad_id},
+        ],
+    }
+    rv = client.post('/orders', json=payload)
+    assert rv.status_code == 400
+
+
 def test_update_order_status_validation(client, sample_data):
     item_id = sample_data['items']['Sandwich']
     rv = client.post('/orders', json={'seat': '15C', 'items': [{'item_id': item_id}], 'payment_method': 'cash'})


### PR DESCRIPTION
## Summary
- validate that all item IDs exist before creating an order
- return 400 from POST /orders when an unknown item ID is supplied
- test invalid item ID handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f391bdec83318b6b305eed9ba977