### PR TITLE
Add auth to integration notifications

### DIFF
--- a/airservice/api/integration.py
+++ b/airservice/api/integration.py
@@ -1,6 +1,8 @@
 import json
 from flask import Blueprint, jsonify, request, current_app
 
+from .admin import auth_required
+
 from ..models import db, OutgoingMessage
 from ..events import register_queue, unregister_queue
 from ..tasks import task_queue, process_outgoing_message
@@ -81,6 +83,7 @@ def notifications():
             schema:
               type: string
     """
+    auth_required()
     def stream():
         q = register_queue()
         try:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,13 +1,14 @@
 from queue import Queue
 from unittest.mock import patch
 from airservice.api import integration
+from conftest import auth_header
 
 
 def test_sse_notifications(app):
     q = Queue()
     with patch('airservice.api.integration.register_queue', lambda: q), \
          patch('airservice.api.integration.unregister_queue', lambda _q: None):
-        with app.test_request_context('/'):
+        with app.test_request_context('/', headers=auth_header()):
             q.put({'hello': 'world'})
             resp = integration.notifications()
             gen = resp.response


### PR DESCRIPTION
## Summary
- secure the integration notifications SSE endpoint with `auth_required`
- adjust the notifications test to pass basic auth

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f4c1186c833186de66daa9d1d4d0