### PR TITLE
Add gettext to API responses

### DIFF
--- a/airservice/api/integration.py
+++ b/airservice/api/integration.py
@@ -1,5 +1,6 @@
 import json
 from flask import Blueprint, jsonify, request, current_app
+from flask_babel import gettext
 
 from .admin import auth_required
 
@@ -29,7 +30,7 @@ def send_to_ai():
     db.session.add(msg)
     db.session.commit()
     task_queue.enqueue(process_outgoing_message, msg.id)
-    return jsonify({'queued': msg.id})
+    return jsonify({'queued': msg.id, 'message': gettext('Message queued')})
 
 
 @integration_bp.route('/integration/sync', methods=['POST'])
@@ -51,7 +52,7 @@ def sync_ground():
     db.session.add(msg)
     db.session.commit()
     task_queue.enqueue(process_outgoing_message, msg.id)
-    return jsonify({'queued': msg.id})
+    return jsonify({'queued': msg.id, 'message': gettext('Message queued')})
 
 
 @integration_bp.route('/retry_pending')
@@ -67,7 +68,7 @@ def retry_pending():
     for m in msgs:
         task_queue.enqueue(process_outgoing_message, m.id)
     db.session.commit()
-    return jsonify({'retried': len(msgs)})
+    return jsonify({'retried': len(msgs), 'message': gettext('Messages retried')})
 
 
 @integration_bp.route('/notifications')

--- a/airservice/services/order_service.py
+++ b/airservice/services/order_service.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List, Tuple
+from flask_babel import gettext
 
 from ..models import db, Item, Order, OrderItem
 from ..events import push_event
@@ -26,7 +27,9 @@ def create_order(seat: str, items: List[dict], *, payment_method: str | None = N
         else:
             validated_items.append((item, it.get("quantity", 1)))
     if missing_ids:
-        raise ValueError(f"Invalid item IDs: {missing_ids}")
+        raise ValueError(
+            gettext('Invalid item IDs: %(ids)s') % {'ids': missing_ids}
+        )
 
     order = Order(seat=seat, idempotency_key=idempotency_key, payment_method=payment_method)
     db.session.add(order)

--- a/airservice/translations/en/LC_MESSAGES/messages.po
+++ b/airservice/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-06-08 19:24+0000\n"
+"POT-Creation-Date: 2025-06-08 20:46+0000\n"
 "PO-Revision-Date: 2025-06-08 19:24+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,20 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: airservice/api/orders.py:17
+#: airservice/api/integration.py:33 airservice/api/integration.py:55
+msgid "Message queued"
+msgstr "Message queued"
+
+#: airservice/api/integration.py:71
+msgid "Messages retried"
+msgstr "Messages retried"
+
+#: airservice/api/orders.py:53
 msgid "Invalid payload"
 msgstr "Invalid payload"
+
+#: airservice/services/order_service.py:31
+#, python-format
+msgid "Invalid item IDs: %(ids)s"
+msgstr "Invalid item IDs: %(ids)s"
 

--- a/airservice/translations/ru/LC_MESSAGES/messages.po
+++ b/airservice/translations/ru/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-06-08 19:24+0000\n"
+"POT-Creation-Date: 2025-06-08 20:46+0000\n"
 "PO-Revision-Date: 2025-06-08 19:24+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -19,7 +19,20 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: airservice/api/orders.py:17
+#: airservice/api/integration.py:33 airservice/api/integration.py:55
+msgid "Message queued"
+msgstr "Сообщение поставлено в очередь"
+
+#: airservice/api/integration.py:71
+msgid "Messages retried"
+msgstr "Сообщения повторно отправлены"
+
+#: airservice/api/orders.py:53
 msgid "Invalid payload"
 msgstr "Неверные данные"
+
+#: airservice/services/order_service.py:31
+#, python-format
+msgid "Invalid item IDs: %(ids)s"
+msgstr "Неверные ID товаров: %(ids)s"
 

--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-06-08 19:24+0000\n"
+"POT-Creation-Date: 2025-06-08 20:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,20 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: airservice/api/orders.py:17
+#: airservice/api/integration.py:33 airservice/api/integration.py:55
+msgid "Message queued"
+msgstr ""
+
+#: airservice/api/integration.py:71
+msgid "Messages retried"
+msgstr ""
+
+#: airservice/api/orders.py:53
 msgid "Invalid payload"
+msgstr ""
+
+#: airservice/services/order_service.py:31
+#, python-format
+msgid "Invalid item IDs: %(ids)s"
 msgstr ""
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -17,3 +17,21 @@ def test_invalid_payload_lang_param_precedence(client):
     rv = client.post('/orders?lang=ru', json={}, headers={'Accept-Language': 'en'})
     assert rv.status_code == 400
     assert rv.get_json()['error'] == 'Неверные данные'
+
+
+def test_invalid_item_ids_ru(client, sample_data):
+    bad_id = max(sample_data['items'].values()) + 1
+    payload = {'seat': '1A', 'items': [{'item_id': bad_id}]}
+    rv = client.post('/orders', json=payload, headers={'Accept-Language': 'ru'})
+    assert rv.status_code == 400
+    assert 'Неверные ID товаров' in rv.get_json()['error']
+
+
+def test_invalid_item_ids_en(client, sample_data):
+    bad_id = max(sample_data['items'].values()) + 1
+    payload = {'seat': '1A', 'items': [{'item_id': bad_id}]}
+    rv = client.post('/orders', json=payload, headers={'Accept-Language': 'en'})
+    assert rv.status_code == 400
+    assert 'Invalid item IDs' in rv.get_json()['error']
+
+


### PR DESCRIPTION
## Summary
- add i18n support for order creation errors and integration messages
- update ru/en translations
- test translations for invalid item IDs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f5d232d483318269246bcf2d8fb6