### PR TITLE
Add API layer for frontend screens

### DIFF
--- a/frontend_proto/InFlightApp/src/api/api.ts
+++ b/frontend_proto/InFlightApp/src/api/api.ts
@@ -1,0 +1,44 @@
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000';
+
+async function handleResponse(res: Response) {
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function getCatalog() {
+  const res = await fetch(`${API_URL}/catalog`);
+  return handleResponse(res);
+}
+
+export async function getCategories() {
+  const res = await fetch(`${API_URL}/catalog/categories`);
+  return handleResponse(res);
+}
+
+export interface CreateOrderPayload {
+  seat: string;
+  items: { item_id: number | string; quantity: number }[];
+  payment_method?: string;
+}
+
+export async function createOrder(payload: CreateOrderPayload) {
+  const res = await fetch(`${API_URL}/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse(res);
+}
+
+export async function getOrder(id: string) {
+  const res = await fetch(`${API_URL}/orders/${id}`);
+  return handleResponse(res);
+}
+
+export async function listOrders() {
+  const res = await fetch(`${API_URL}/admin/orders`);
+  return handleResponse(res);
+}

--- a/frontend_proto/InFlightApp/src/screens/CatalogScreen.tsx
+++ b/frontend_proto/InFlightApp/src/screens/CatalogScreen.tsx
@@ -1,15 +1,35 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, FlatList, StyleSheet, Image } from 'react-native';
-import { Card, Searchbar, Chip, Text, Button, useTheme } from 'react-native-paper';
-import { Product } from '../types';
+import { Card, Searchbar, Chip, Text, Button, useTheme, ActivityIndicator } from 'react-native-paper';
+import { Product, Category } from '../types';
 import { useTranslation } from 'react-i18next';
-import { products, categories } from '../data/products';
+import { getCatalog, getCategories } from '../api/api';
 
 const CatalogScreen = ({ navigation }: any) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        setLoading(true);
+        const [prodData, catData] = await Promise.all([getCatalog(), getCategories()]);
+        setProducts(prodData);
+        setCategories(catData);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadData();
+  }, []);
 
   const filteredProducts = products.filter((product) => {
     const matchesSearch = product.name.toLowerCase().includes(searchQuery.toLowerCase());
@@ -58,6 +78,22 @@ const CatalogScreen = ({ navigation }: any) => {
       </Card.Actions>
     </Card>
   );
+
+  if (loading) {
+    return (
+      <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
+        <Text style={{ color: theme.colors.error }}>{error}</Text>
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -203,6 +239,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   viewButton: {
     width: '100%',

--- a/frontend_proto/InFlightApp/src/screens/OrderHistoryScreen.tsx
+++ b/frontend_proto/InFlightApp/src/screens/OrderHistoryScreen.tsx
@@ -3,29 +3,26 @@ import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { Card, Text, Chip, Divider, Button, ActivityIndicator, useTheme } from 'react-native-paper';
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
-import { getOrdersByUserId } from '../data/orders';
+import { listOrders } from '../api/api';
 
 const OrderHistoryScreen = ({ navigation }: any) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
 
   // Получение данных о заказах
   useEffect(() => {
-    // Эмуляция загрузки данных с сервера
     const loadOrders = async () => {
       try {
         setLoading(true);
-        // Имитация задержки сети
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        
-        // В реальном приложении здесь был бы API-запрос
-        const userOrders = getOrdersByUserId('user123');
-        setOrders(userOrders);
-      } catch (error) {
-        console.error('Ошибка при загрузке заказов:', error);
+        const data = await listOrders();
+        setOrders(data);
+      } catch (err: any) {
+        console.error('Ошибка при загрузке заказов:', err);
+        setError(err.message);
       } finally {
         setLoading(false);
       }
@@ -157,6 +154,14 @@ const OrderHistoryScreen = ({ navigation }: any) => {
     return (
       <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
         <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
+        <Text style={{ color: theme.colors.error }}>{error}</Text>
       </View>
     );
   }

--- a/frontend_proto/InFlightApp/src/screens/OrderStatusScreen.tsx
+++ b/frontend_proto/InFlightApp/src/screens/OrderStatusScreen.tsx
@@ -3,57 +3,25 @@ import { View, StyleSheet } from 'react-native';
 import { Card, Text, ActivityIndicator, Button, useTheme } from 'react-native-paper';
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
-import { getOrderById } from '../data/orders';
+import { getOrder } from '../api/api';
 
 const OrderStatusScreen = ({ route, navigation }: any) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     // Эмуляция загрузки данных с сервера
     const loadOrder = async () => {
       try {
         setLoading(true);
-        // Имитация задержки сети
-        await new Promise(resolve => setTimeout(resolve, 800));
-        
-        // Получаем заказ из данных
-        const foundOrder = getOrderById(route.params.orderId);
-        
-        if (foundOrder) {
-          setOrder(foundOrder);
-        } else {
-          // Если заказ не найден в данных, создаем mock-заказ с ID из параметров
-          // Это для случая, когда мы приходим на экран после оплаты
-          const mockOrder: Order = {
-            id: route.params.orderId,
-            userId: 'user123',
-            items: [
-              {
-                productId: 'drinks-3',
-                name: 'Кофе Американо',
-                quantity: 2,
-                price: 280,
-              },
-              {
-                productId: 'food-1',
-                name: 'Куриное филе с овощами',
-                quantity: 1,
-                price: 750,
-              },
-            ],
-            totalAmount: 1310,
-            status: OrderStatus.PREPARING,
-            seatNumber: '12A',
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          };
-          setOrder(mockOrder);
-        }
-      } catch (error) {
-        console.error('Ошибка при загрузке заказа:', error);
+        const data = await getOrder(route.params.orderId);
+        setOrder(data);
+      } catch (err: any) {
+        console.error('Ошибка при загрузке заказа:', err);
+        setError(err.message);
       } finally {
         setLoading(false);
       }
@@ -112,6 +80,23 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
     return (
       <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
         <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.errorContainer, { backgroundColor: theme.colors.background }]}>
+        <Text style={{ color: theme.colors.error }}>{error}</Text>
+        <Button
+          mode="contained"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+          buttonColor={theme.colors.primary}
+          textColor={theme.colors.onPrimary}
+        >
+          {t('common.back')}
+        </Button>
       </View>
     );
   }

--- a/frontend_proto/InFlightApp/src/screens/ProfileScreen.tsx
+++ b/frontend_proto/InFlightApp/src/screens/ProfileScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, ScrollView, Linking } from 'react-native';
 import { Card, Text, Switch, Button, List, Divider, useTheme } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import DirectLinkButton from '../components/DirectLinkButton';
-import { getOrdersByUserId } from '../data/orders';
+import { listOrders } from '../api/api';
 
 const ProfileScreen = ({ navigation }: any) => {
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
@@ -18,8 +18,19 @@ const ProfileScreen = ({ navigation }: any) => {
   };
 
   // Получаем количество заказов для отображения
-  const userOrders = getOrdersByUserId('user123');
-  const ordersCount = userOrders.length;
+  const [ordersCount, setOrdersCount] = useState(0);
+
+  useEffect(() => {
+    const fetchOrders = async () => {
+      try {
+        const data = await listOrders();
+        setOrdersCount(data.length);
+      } catch (err) {
+        console.error('Ошибка при получении заказов:', err);
+      }
+    };
+    fetchOrders();
+  }, []);
 
   const handleLogout = async () => {
     try {


### PR DESCRIPTION
## Summary
- add an API helper using `fetch` and configurable base URL
- use API in catalog, order history, profile and order status screens
- handle loading and error states

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npx tsc -p frontend_proto/InFlightApp/tsconfig.json --noEmit` *(fails: Cannot use JSX unless '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6846202bb1108331a953b3582a5017f2