### PR TITLE
Add frontend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,30 @@
 
 Данные по умолчанию хранятся в SQLite-файле `airservice.db`. Чтобы использовать PostgreSQL, задайте `DATABASE_URL`.
 
+## Фронтенд
+
+Клиентское приложение находится в каталоге `frontend_proto`. Чтобы установить зависимости и запустить его:
+
+```bash
+cd frontend_proto/InFlightApp
+npm install
+npm start # или expo start
+```
+
+Перед запуском укажите адрес backend-сервера через переменную `EXPO_PUBLIC_API_URL`:
+
+```bash
+EXPO_PUBLIC_API_URL=http://localhost:5000 npm start
+```
+
+Для полной функциональности (уведомления и фоновые задачи) требуется Redis и запущенный воркер:
+
+```bash
+python run_worker.py
+```
+
+Подробнее см. [frontend_proto/README.md](frontend_proto/README.md).
+
 ## Лицензия
 
 Этот проект распространяется под лицензией MIT.

--- a/frontend_proto/README.md
+++ b/frontend_proto/README.md
@@ -40,6 +40,12 @@ npm start # или expo start
 EXPO_PUBLIC_API_URL=http://localhost:5000 npm start
 ```
 
+Для полной функциональности (уведомления и фоновые задачи) требуется Redis и запущенный воркер:
+
+```bash
+python run_worker.py
+```
+
 ## Демо-аккаунты
 
 - **Обычный пользователь**: user@example.com / password


### PR DESCRIPTION
## Summary
- document how to start the React Native app
- show how to set `EXPO_PUBLIC_API_URL`
- mention running the queue worker and Redis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684624e0b7d08331acac04ec40c9f154