### PR TITLE
Add seat-based order retrieval

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ import OrderHistoryScreen from './screens/OrderHistoryScreen';
 declare global {
   namespace ReactNavigation {
     interface RootParamList {
-      Login: { onLogin: (isAdmin: boolean) => void };
+      Login: { onLogin: (isAdmin: boolean, seatNumber: string) => void };
       MainApp: undefined;
       AdminRoot: undefined;
       ProductDetails: { id: string };
@@ -35,7 +35,7 @@ declare global {
       CatalogScreen: undefined;
       CartScreen: undefined;
       ProfileScreen: undefined;
-      LoginScreen: { onLogin: (isAdmin: boolean) => void };
+      LoginScreen: { onLogin: (isAdmin: boolean, seatNumber: string) => void };
       AdminPanel: undefined;
       ProductDetailsScreen: { id: string };
       OrderStatusScreen: { id: string };
@@ -143,7 +143,7 @@ const linking = {
 };
 
 // Main tab navigator for authenticated users
-const MainTabNavigator = () => {
+const MainTabNavigator = ({ seatNumber }: { seatNumber: string }) => {
   const { t } = useTranslation();
   
   return (
@@ -181,7 +181,11 @@ const MainTabNavigator = () => {
     >
       <Tab.Screen name={t('navigation.catalog')} component={CatalogScreen} />
       <Tab.Screen name={t('navigation.cart')} component={CartScreen} />
-      <Tab.Screen name={t('navigation.profile')} component={ProfileScreen} />
+      <Tab.Screen
+        name={t('navigation.profile')}
+        component={ProfileScreen}
+        initialParams={{ seatNumber }}
+      />
     </Tab.Navigator>
   );
 };
@@ -215,6 +219,7 @@ const RootStackNavigator = () => {
   const { t } = useTranslation();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [seatNumber, setSeatNumber] = useState('');
 
   // Mock authentication check - in a real app, this would check for a valid token
   useEffect(() => {
@@ -255,18 +260,17 @@ const RootStackNavigator = () => {
         name="Login" 
         component={LoginScreen} 
         options={{ headerShown: false }}
-        initialParams={{ onLogin: (isAdmin: boolean) => {
+        initialParams={{ onLogin: (isAdmin: boolean, seat: string) => {
           setIsLoggedIn(true);
           setIsAdmin(isAdmin);
+          setSeatNumber(seat);
         }}}
       />
       
       {/* Основные экраны приложения */}
-      <Stack.Screen 
-        name="MainApp" 
-        component={MainTabNavigator}
-        options={{ headerShown: false }} 
-      />
+      <Stack.Screen name="MainApp" options={{ headerShown: false }}>
+        {() => <MainTabNavigator seatNumber={seatNumber} />}
+      </Stack.Screen>
       
       {/* Админ-панель */}
       <Stack.Screen 
@@ -298,10 +302,11 @@ const RootStackNavigator = () => {
         component={CartScreen} 
         options={{ title: t('navigation.cart') }}
       />
-      <Stack.Screen 
-        name="ProfileScreen" 
-        component={ProfileScreen} 
+      <Stack.Screen
+        name="ProfileScreen"
+        component={ProfileScreen}
         options={{ title: t('navigation.profile') }}
+        initialParams={{ seatNumber }}
       />
       <Stack.Screen 
         name="LoginScreen" 
@@ -328,10 +333,11 @@ const RootStackNavigator = () => {
         component={PaymentScreen} 
         options={{ title: t('payment.title') }}
       />
-      <Stack.Screen 
-        name="OrderHistoryScreen" 
-        component={OrderHistoryScreen} 
+      <Stack.Screen
+        name="OrderHistoryScreen"
+        component={OrderHistoryScreen}
         options={{ title: t('navigation.orderHistory') }}
+        initialParams={{ seatNumber }}
       />
     </Stack.Navigator>
   );

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -38,7 +38,8 @@ export async function getOrder(id: string) {
   return handleResponse(res);
 }
 
-export async function listOrders() {
-  const res = await fetch(`${API_URL}/admin/orders`);
+export async function listOrders({ seat, status }: { seat: string; status?: string }) {
+  const statusQuery = status ? `&status=${status}` : '';
+  const res = await fetch(`${API_URL}/orders?seat=${seat}${statusQuery}`);
   return handleResponse(res);
 }

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -7,7 +7,7 @@ interface LoginScreenProps {
   navigation: any;
   route: {
     params: {
-      onLogin: (isAdmin: boolean) => void;
+      onLogin: (isAdmin: boolean, seatNumber: string) => void;
     };
   };
 }
@@ -46,7 +46,7 @@ const LoginScreen = ({ navigation, route }: LoginScreenProps) => {
         // Simulate request delay
         await new Promise(resolve => setTimeout(resolve, 1000));
         
-        route.params.onLogin(isAdmin);
+        route.params.onLogin(isAdmin, seatNumber);
       } else {
         if (!seatNumber) {
           setError(t('auth.seatRequired'));
@@ -57,7 +57,7 @@ const LoginScreen = ({ navigation, route }: LoginScreenProps) => {
         // Simulate request delay
         await new Promise(resolve => setTimeout(resolve, 1000));
         
-        route.params.onLogin(false);
+        route.params.onLogin(false, seatNumber);
       }
     } catch (err: any) {
       setError(err.message || t('auth.invalidCredentials'));

--- a/frontend/src/screens/OrderHistoryScreen.tsx
+++ b/frontend/src/screens/OrderHistoryScreen.tsx
@@ -5,9 +5,10 @@ import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
 import { listOrders } from '../api/api';
 
-const OrderHistoryScreen = ({ navigation }: any) => {
+const OrderHistoryScreen = ({ navigation, route }: any) => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const seatNumber = route.params?.seatNumber as string;
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -18,7 +19,7 @@ const OrderHistoryScreen = ({ navigation }: any) => {
     const loadOrders = async () => {
       try {
         setLoading(true);
-        const data = await listOrders();
+        const data = await listOrders({ seat: seatNumber, status: selectedFilter || undefined });
         setOrders(data);
       } catch (err: any) {
         console.error('Ошибка при загрузке заказов:', err);

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -5,7 +5,8 @@ import { useTranslation } from 'react-i18next';
 import DirectLinkButton from '../components/DirectLinkButton';
 import { listOrders } from '../api/api';
 
-const ProfileScreen = ({ navigation }: any) => {
+const ProfileScreen = ({ navigation, route }: any) => {
+  const seatNumber = route.params?.seatNumber as string;
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [darkModeEnabled, setDarkModeEnabled] = useState(true); // По умолчанию включен темный режим
   const theme = useTheme();
@@ -23,7 +24,7 @@ const ProfileScreen = ({ navigation }: any) => {
   useEffect(() => {
     const fetchOrders = async () => {
       try {
-        const data = await listOrders();
+        const data = await listOrders({ seat: seatNumber });
         setOrdersCount(data.length);
       } catch (err) {
         console.error('Ошибка при получении заказов:', err);
@@ -104,7 +105,7 @@ const ProfileScreen = ({ navigation }: any) => {
                 {ordersCount}
               </Text>
             </View>}
-            onPress={() => navigation.navigate('OrderHistoryScreen')}
+            onPress={() => navigation.navigate('OrderHistoryScreen', { seatNumber })}
           />
           
           <Divider style={{ backgroundColor: theme.colors.outline }} />
@@ -155,6 +156,7 @@ const ProfileScreen = ({ navigation }: any) => {
             <DirectLinkButton
               screenName="OrderHistoryScreen"
               style={styles.linkButton}
+              params={{ seatNumber }}
             >
               {t('navigation.orderHistory')}
             </DirectLinkButton>


### PR DESCRIPTION
## Summary
- extend login callback to also store seat number in `App.tsx`
- pass seat number to profile and order history screens via navigation params
- update profile and order history screens to query orders for that seat
- adjust API listOrders() call for seat-based queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462df5066083319f60aa0e05f1afec