### PR TITLE
Handle optional catalog fields

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,3 +1,5 @@
+import { Product, Category } from '../types';
+
 const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000';
 
 async function handleResponse(res: Response) {
@@ -8,14 +10,40 @@ async function handleResponse(res: Response) {
   return res.json();
 }
 
-export async function getCatalog() {
+export async function getCatalog(): Promise<Product[]> {
   const res = await fetch(`${API_URL}/catalog`);
-  return handleResponse(res);
+  const data = await handleResponse(res);
+  return data.map((item: any) => ({
+    id: String(item.id),
+    name: item.name,
+    description: item.description || undefined,
+    price: item.price,
+    categoryId: item.category ? String(item.category) : '',
+    image: item.image || undefined,
+    inStock: item.available,
+  }));
 }
 
-export async function getCategories() {
+function flattenCategories(nodes: any[]): any[] {
+  return nodes.reduce((acc: any[], node: any) => {
+    acc.push(node);
+    if (node.children) {
+      acc.push(...flattenCategories(node.children));
+    }
+    return acc;
+  }, []);
+}
+
+export async function getCategories(): Promise<Category[]> {
   const res = await fetch(`${API_URL}/catalog/categories`);
-  return handleResponse(res);
+  const data = await handleResponse(res);
+  const flat = flattenCategories(data);
+  return flat.map((c: any) => ({
+    id: String(c.id),
+    name: c.name,
+    description: c.description || undefined,
+    image: c.image || undefined,
+  }));
 }
 
 export interface CreateOrderPayload {

--- a/frontend/src/screens/CatalogScreen.tsx
+++ b/frontend/src/screens/CatalogScreen.tsx
@@ -43,7 +43,14 @@ const CatalogScreen = ({ navigation }: any) => {
       onPress={() => navigation.navigate('ProductDetails', { product: item })}
     >
       <View style={styles.imageContainer}>
-        <Card.Cover source={{ uri: item.image }} style={styles.cardImage} />
+        <Card.Cover
+          source={
+            item.image
+              ? { uri: item.image }
+              : require('../assets/icon.png')
+          }
+          style={styles.cardImage}
+        />
       </View>
       <Card.Content style={styles.cardContent}>
         <Text 
@@ -56,13 +63,15 @@ const CatalogScreen = ({ navigation }: any) => {
         <Text style={[styles.productPrice, { color: theme.colors.primary }]}>
           {item.price} {t('common.currency')}
         </Text>
-        <Text 
-          numberOfLines={2} 
-          ellipsizeMode="tail" 
-          style={[styles.productDescription, { color: theme.colors.onSurfaceVariant }]}
-        >
-          {item.description}
-        </Text>
+        {item.description ? (
+          <Text
+            numberOfLines={2}
+            ellipsizeMode="tail"
+            style={[styles.productDescription, { color: theme.colors.onSurfaceVariant }]}
+          >
+            {item.description}
+          </Text>
+        ) : null}
       </Card.Content>
       <Card.Actions style={styles.cardActions}>
         <Button 
@@ -128,7 +137,16 @@ const CatalogScreen = ({ navigation }: any) => {
               style={styles.chip}
               selectedColor={theme.colors.primary}
               textStyle={{ color: selectedCategory === item.id ? theme.colors.onPrimary : theme.colors.onSurface }}
-              avatar={<Image source={{ uri: item.image }} style={styles.categoryImage} />}
+              avatar={
+                <Image
+                  source={
+                    item.image
+                      ? { uri: item.image }
+                      : require('../assets/icon.png')
+                  }
+                  style={styles.categoryImage}
+                />
+              }
             >
               {item.name}
             </Chip>

--- a/frontend/src/screens/ProductDetailsScreen.tsx
+++ b/frontend/src/screens/ProductDetailsScreen.tsx
@@ -33,16 +33,27 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
   return (
     <ScrollView style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-        <Card.Cover source={{ uri: product.image }} style={styles.image} />
+        <Card.Cover
+          source={
+            product.image
+              ? { uri: product.image }
+              : require('../assets/icon.png')
+          }
+          style={styles.image}
+        />
         <Card.Content>
           <View style={styles.header}>
             <Text style={[styles.title, { color: theme.colors.onSurface }]}>{product.name}</Text>
             <Text style={[styles.price, { color: theme.colors.primary }]}>{product.price} {t('common.currency')}</Text>
           </View>
           
-          <Text style={[styles.description, { color: theme.colors.onSurfaceVariant }]}>{product.description}</Text>
+          {product.description ? (
+            <Text style={[styles.description, { color: theme.colors.onSurfaceVariant }]}>
+              {product.description}
+            </Text>
+          ) : null}
           
-          {!product.inStock && (
+          {product.inStock === false && (
             <View style={[styles.outOfStockBadge, { backgroundColor: theme.colors.error }]}>
               <Text style={styles.outOfStockText}>{t('catalog.outOfStock')}</Text>
             </View>
@@ -154,7 +165,7 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
         mode="contained"
         onPress={handleAddToCart}
         style={styles.addButton}
-        disabled={!product.inStock}
+        disabled={product.inStock === false}
         buttonColor={theme.colors.primary}
         textColor={theme.colors.onPrimary}
       >

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,11 +16,11 @@ export interface UserPreferences {
 export interface Product {
   id: string;
   name: string;
-  description: string;
+  description?: string;
   price: number;
   categoryId: string;
-  image: string;
-  inStock: boolean;
+  image?: string;
+  inStock?: boolean;
   ingredients?: string | null;
   nutritionalInfo?: {
     calories: number;
@@ -63,8 +63,8 @@ export enum OrderStatus {
 export interface Category {
   id: string;
   name: string;
-  description: string;
-  image: string;
+  description?: string;
+  image?: string;
 }
 
 export interface AnalyticsData {


### PR DESCRIPTION
## Summary
- allow optional description, image and inStock fields in frontend types
- map backend responses to these optional fields
- use existing icon as placeholder in product and category lists
- show placeholders or hide empty descriptions in catalog and product screens
- remove unsupported binary placeholder images

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68462eb8dcd48331a8da088cb5d6f49b