### PR TITLE
Map API order statuses to enums

### DIFF
--- a/frontend/src/screens/OrderHistoryScreen.tsx
+++ b/frontend/src/screens/OrderHistoryScreen.tsx
@@ -3,7 +3,7 @@ import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { Card, Text, Chip, Divider, Button, ActivityIndicator, useTheme } from 'react-native-paper';
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
-import { listOrders } from '../api/api';
+import { listOrders, mapOrderStatus } from '../api/api';
 
 const OrderHistoryScreen = ({ navigation, route }: any) => {
   const theme = useTheme();
@@ -20,7 +20,10 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
       try {
         setLoading(true);
         const data = await listOrders({ seat: seatNumber, status: selectedFilter || undefined });
-        setOrders(data);
+        const mapped = Array.isArray(data)
+          ? data.map(order => ({ ...order, status: mapOrderStatus(order.status) }))
+          : [];
+        setOrders(mapped as Order[]);
       } catch (err: any) {
         console.error('Ошибка при загрузке заказов:', err);
         setError(err.message);

--- a/frontend/src/screens/OrderStatusScreen.tsx
+++ b/frontend/src/screens/OrderStatusScreen.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet } from 'react-native';
 import { Card, Text, ActivityIndicator, Button, useTheme } from 'react-native-paper';
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
-import { getOrder } from '../api/api';
+import { getOrder, mapOrderStatus } from '../api/api';
 
 const OrderStatusScreen = ({ route, navigation }: any) => {
   const theme = useTheme();
@@ -18,6 +18,9 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
       try {
         setLoading(true);
         const data = await getOrder(route.params.orderId);
+        if (data) {
+          data.status = mapOrderStatus(data.status);
+        }
         setOrder(data);
       } catch (err: any) {
         console.error('Ошибка при загрузке заказа:', err);


### PR DESCRIPTION
## Summary
- map backend order statuses to `OrderStatus` enum
- update `OrderStatusScreen` and `OrderHistoryScreen` to use mapped values

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684632e97de88331bdd49f0922d3e18a