### PR TITLE
Add category_id to catalog API

### DIFF
--- a/airservice/api/catalog.py
+++ b/airservice/api/catalog.py
@@ -73,6 +73,8 @@ def catalog():
                     type: boolean
                   category:
                     type: string
+                  category_id:
+                    type: integer
     """
     qs = Item.query
     category = request.args.get('category')
@@ -113,6 +115,7 @@ def catalog():
             'available': i.available,
             'service': i.is_service,
             'category': i.category.name if i.category else None,
+            'category_id': i.category.id if i.category else None,
         })
     return jsonify(data)
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -18,7 +18,9 @@ export async function getCatalog(): Promise<Product[]> {
     name: item.name,
     description: item.description || undefined,
     price: item.price,
-    categoryId: item.category ? String(item.category) : '',
+    categoryId: item.category_id !== undefined && item.category_id !== null
+      ? String(item.category_id)
+      : '',
     image: item.image || undefined,
     inStock: item.available,
   }));

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,7 +6,10 @@ def test_catalog_filters(client, sample_data):
     # all items
     rv = client.get('/catalog')
     assert rv.status_code == 200
-    assert len(rv.get_json()) == 9
+    data = rv.get_json()
+    assert len(data) == 9
+    # ensure category name and id are present
+    assert {'category', 'category_id'} <= set(data[0].keys())
 
     # by category
     food_cat = sample_data['categories']['Food']


### PR DESCRIPTION
## Summary
- provide `category_id` in `/catalog` endpoint response
- load product `categoryId` using new field
- verify new fields in catalog tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846358213d88331a0c4156bb6e75c16