### PR TITLE
Add order totals and item details

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -78,20 +78,35 @@ export function mapOrderStatus(status: string): OrderStatus {
   }
 }
 
+function mapOrder(data: any) {
+  return {
+    id: String(data.id),
+    items: Array.isArray(data.items)
+      ? data.items.map((i: any) => ({
+          productId: String(i.item_id),
+          name: i.name,
+          price: i.price,
+          quantity: i.quantity,
+        }))
+      : [],
+    totalAmount: data.total,
+    status: mapOrderStatus(data.status),
+    seatNumber: data.seat,
+    createdAt: data.created_at ? new Date(data.created_at) : undefined,
+    updatedAt: data.updated_at ? new Date(data.updated_at) : undefined,
+    paymentMethod: data.payment_method,
+  };
+}
+
 export async function getOrder(id: string) {
   const res = await fetch(`${API_URL}/orders/${id}`);
   const data = await handleResponse(res);
-  if (data && typeof data.status === 'string') {
-    data.status = mapOrderStatus(data.status);
-  }
-  return data;
+  return mapOrder(data);
 }
 
 export async function listOrders({ seat, status }: { seat: string; status?: string }) {
   const statusQuery = status ? `&status=${status}` : '';
   const res = await fetch(`${API_URL}/orders?seat=${seat}${statusQuery}`);
   const data = await handleResponse(res);
-  return Array.isArray(data)
-    ? data.map((o) => ({ ...o, status: mapOrderStatus(o.status) }))
-    : data;
+  return Array.isArray(data) ? data.map(mapOrder) : data;
 }

--- a/frontend/src/data/orders.ts
+++ b/frontend/src/data/orders.ts
@@ -12,7 +12,6 @@ export const orders: Order[] = [
   // Заказ №1 - Доставлен (завершен)
   {
     id: 'order-20231015-001',
-    userId: 'user123',
     items: [
       {
         productId: 'food-2',
@@ -44,7 +43,6 @@ export const orders: Order[] = [
   // Заказ №2 - В процессе доставки
   {
     id: 'order-20231015-002',
-    userId: 'user123',
     items: [
       {
         productId: 'drinks-3',
@@ -70,7 +68,6 @@ export const orders: Order[] = [
   // Заказ №3 - Готовится
   {
     id: 'order-20231015-003',
-    userId: 'user123',
     items: [
       {
         productId: 'food-1',
@@ -96,7 +93,6 @@ export const orders: Order[] = [
   // Заказ №4 - Ожидает обработки
   {
     id: 'order-20231015-004',
-    userId: 'user123',
     items: [
       {
         productId: 'alcohol-1',
@@ -122,7 +118,6 @@ export const orders: Order[] = [
   // Заказ №5 - Отменен
   {
     id: 'order-20231014-001',
-    userId: 'user123',
     items: [
       {
         productId: 'food-5',
@@ -142,7 +137,6 @@ export const orders: Order[] = [
   // Заказ №6 - Большой заказ (завершен)
   {
     id: 'order-20231013-001',
-    userId: 'user123',
     items: [
       {
         productId: 'food-3',
@@ -179,9 +173,6 @@ export const orders: Order[] = [
 ];
 
 // Получить заказы по ID пользователя
-export const getOrdersByUserId = (userId: string): Order[] => {
-  return orders.filter(order => order.userId === userId);
-};
 
 // Получить заказ по ID
 export const getOrderById = (orderId: string): Order | undefined => {

--- a/frontend/src/screens/AdminPanel.tsx
+++ b/frontend/src/screens/AdminPanel.tsx
@@ -34,7 +34,6 @@ const AdminPanel = ({ navigation }: any) => {
         recentOrders: [
           {
             id: 'order1',
-            userId: 'user1',
             items: [{ productId: '1', quantity: 2, price: 3.99 }],
             totalAmount: 7.98,
             status: OrderStatus.COMPLETED,
@@ -44,7 +43,6 @@ const AdminPanel = ({ navigation }: any) => {
           },
           {
             id: 'order2',
-            userId: 'user2',
             items: [{ productId: '3', quantity: 1, price: 25.99 }],
             totalAmount: 25.99,
             status: OrderStatus.DELIVERING,
@@ -54,7 +52,6 @@ const AdminPanel = ({ navigation }: any) => {
           },
           {
             id: 'order3',
-            userId: 'user3',
             items: [
               { productId: '2', quantity: 1, price: 5.99 },
               { productId: '4', quantity: 1, price: 9.99 },

--- a/frontend/src/screens/OrderHistoryScreen.tsx
+++ b/frontend/src/screens/OrderHistoryScreen.tsx
@@ -3,7 +3,7 @@ import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { Card, Text, Chip, Divider, Button, ActivityIndicator, useTheme } from 'react-native-paper';
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
-import { listOrders, mapOrderStatus } from '../api/api';
+import { listOrders } from '../api/api';
 
 const OrderHistoryScreen = ({ navigation, route }: any) => {
   const theme = useTheme();
@@ -20,10 +20,7 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
       try {
         setLoading(true);
         const data = await listOrders({ seat: seatNumber, status: selectedFilter || undefined });
-        const mapped = Array.isArray(data)
-          ? data.map(order => ({ ...order, status: mapOrderStatus(order.status) }))
-          : [];
-        setOrders(mapped as Order[]);
+        setOrders((Array.isArray(data) ? data : []) as Order[]);
       } catch (err: any) {
         console.error('Ошибка при загрузке заказов:', err);
         setError(err.message);

--- a/frontend/src/screens/OrderStatusScreen.tsx
+++ b/frontend/src/screens/OrderStatusScreen.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet } from 'react-native';
 import { Card, Text, ActivityIndicator, Button, useTheme } from 'react-native-paper';
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
-import { getOrder, mapOrderStatus } from '../api/api';
+import { getOrder } from '../api/api';
 
 const OrderStatusScreen = ({ route, navigation }: any) => {
   const theme = useTheme();
@@ -18,9 +18,6 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
       try {
         setLoading(true);
         const data = await getOrder(route.params.orderId);
-        if (data) {
-          data.status = mapOrderStatus(data.status);
-        }
         setOrder(data);
       } catch (err: any) {
         console.error('Ошибка при загрузке заказа:', err);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -35,13 +35,12 @@ export interface Product {
 
 export interface Order {
   id: string;
-  userId: string;
   items: OrderItem[];
   totalAmount: number;
   status: OrderStatus;
   seatNumber: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
   paymentMethod?: string;
 }
 


### PR DESCRIPTION
## Summary
- include price details and totals in order endpoints
- adapt frontend API mapping and order screens
- drop unused userId fields
- update tests for new schema

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463653df048331b519e747d83e813c