### PR TITLE
Align order endpoints and integrate cart

### DIFF
--- a/airservice/api/orders.py
+++ b/airservice/api/orders.py
@@ -126,6 +126,7 @@ def get_order(order_id):
         'status': order.status,
         'items': items,
         'total': total,
+        'created_at': order.created_at.isoformat(),
     })
 
 
@@ -158,5 +159,6 @@ def list_orders():
             'status': o.status,
             'items': items,
             'total': total,
+            'created_at': o.created_at.isoformat(),
         })
     return jsonify(response)

--- a/frontend/src/screens/CartScreen.tsx
+++ b/frontend/src/screens/CartScreen.tsx
@@ -5,6 +5,7 @@ import { OrderItem, PaymentMethod } from '../types';
 import PaymentForm from '../components/PaymentForm';
 import { useTranslation } from 'react-i18next';
 import DirectLinkButton from '../components/DirectLinkButton';
+import { createOrder } from '../api/api';
 
 const CartScreen = ({ navigation, route }: any) => {
   const theme = useTheme();
@@ -56,17 +57,28 @@ const CartScreen = ({ navigation, route }: any) => {
     setShowPaymentModal(true);
   };
 
-  const handlePaymentComplete = (paymentMethod: PaymentMethod) => {
+  const handlePaymentComplete = async (paymentMethod: PaymentMethod) => {
     setShowPaymentModal(false);
     setLoading(true);
-    
-    // In a real app, you would create the order in your backend
-    setTimeout(() => {
+
+    try {
+      const payload = {
+        seat: seatNumber,
+        items: cartItems.map((i) => ({
+          item_id: Number(i.productId),
+          quantity: i.quantity,
+        })),
+        payment_method: paymentMethod.type,
+      };
+      const res = await createOrder(payload);
+      const orderId = res.order_id;
+      setCartItems([]);
+      navigation.navigate('OrderStatus', { orderId: String(orderId) });
+    } catch (err) {
+      console.error('Failed to create order', err);
+    } finally {
       setLoading(false);
-      navigation.navigate('OrderStatus', {
-        orderId: `order-${Date.now()}`,
-      });
-    }, 1000);
+    }
   };
 
   const handlePaymentCancel = () => {


### PR DESCRIPTION
## Summary
- include `created_at` in order API responses
- create orders from CartScreen using backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462c4332d88331ac4b3b744fd51169