### PR TITLE
Fix collection warning for TestConfig

### DIFF
--- a/airservice/config.py
+++ b/airservice/config.py
@@ -22,5 +22,6 @@ class DevConfig(BaseConfig):
 
 
 class TestConfig(BaseConfig):
+    __test__ = False
     TESTING = True
     SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///:memory:")


### PR DESCRIPTION
## Summary
- avoid pytest collecting TestConfig as a test by setting `__test__ = False`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684641856c748331ab4e014313897412