### PR TITLE
Update README with Redis and translation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@
    ```bash
    python run_worker.py
    ```
+   Адрес Redis можно задать через переменную `REDIS_URL` (по умолчанию
+   используется `redis://localhost:6379/0`).
 9. Логи сервера пишутся в файл `airservice.log` в формате JSON и содержат поля
    `timestamp`, `user`, `endpoint` и `message`.
+10. При изменении переводов выполните команду
+    `pybabel compile -d airservice/translations` для сборки `.mo`‑файлов.
 
 ## Использование
 


### PR DESCRIPTION
## Summary
- clarify how to configure Redis with `REDIS_URL`
- add step to compile translations using `pybabel`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846417cb1108331a59efa34f6463db3