### PR TITLE
Improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Запуск
 
+Все приведённые ниже команды следует выполнять из корня репозитория.
+
 1. Установите зависимости:
    ```bash
    pip install -r requirements.txt
@@ -11,8 +13,9 @@
 2. При необходимости укажите строку подключения к БД через переменную `DATABASE_URL`.
    Пример для PostgreSQL:
    `postgresql://user:password@localhost/airservice`.
-3. Выполните миграции (при первом запуске):
+3. Укажите приложение и выполните миграции (при первом запуске):
    ```bash
+   export FLASK_APP=run.py   # или используйте "flask --app run.py ..."
    flask db init      # один раз
    flask db migrate -m "init"
    flask db upgrade


### PR DESCRIPTION
## Summary
- clarify that setup commands run from repo root
- set `FLASK_APP=run.py` before using `flask db`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6846457a1b84833196539f9b15e86877