### PR TITLE
Handle log file cleanup in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import sys
 import base64
 from datetime import datetime
 import json
+import logging
 import pytest
 import subprocess
 from pathlib import Path
@@ -140,4 +141,5 @@ def sample_logs():
         for e in entries:
             f.write(json.dumps(e) + '\n')
     yield entries
+    logging.shutdown()
     os.remove('airservice.log')


### PR DESCRIPTION
## Summary
- import `logging` in `tests/conftest.py`
- call `logging.shutdown()` before removing `airservice.log` in `sample_logs` fixture

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684655b5dae88331b03d02fdc57e710e