### PR TITLE
Fix expo web-build script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "web-build": "expo export:web -o web-build",
+    "web-build": "expo export:web web-build",
     "serve-web": "npx serve web-build",
     "postinstall": "patch-package",
     "fix-icons": "node scripts/fix-icons.js",


### PR DESCRIPTION
## Summary
- fix the web-build npm script for expo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684652156f808331989eba3bc3b240b7