### PR TITLE
Add demo data CLI seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,27 +20,32 @@
    ```
    Команду `flask db migrate` используйте только при создании новых миграций.
 
+4. Заполните таблицы демонстрационными данными:
+   ```bash
+   flask seed-data
+   ```
+
 If an earlier version of the database already exists (for example from a previous clone), delete `airservice.db` or run `flask db downgrade base` before `flask db upgrade`.
-4. Вы можете задать логин администратора через `ADMIN_USERNAME` и пароль
+5. Вы можете задать логин администратора через `ADMIN_USERNAME` и пароль
    через `ADMIN_PASSWORD` или готовый `ADMIN_PASSWORD_HASH`.
    По умолчанию используются значения `admin`/`admin`.
-5. Можно настроить лимит запросов через переменную `API_RATE_LIMIT`
+6. Можно настроить лимит запросов через переменную `API_RATE_LIMIT`
    (например `"200 per hour"`). По умолчанию действует `"100 per hour"`.
-6. Разрешённые origin для CORS можно указать через `FRONTEND_ORIGIN`
+7. Разрешённые origin для CORS можно указать через `FRONTEND_ORIGIN`
    (по умолчанию `*`).
-7. Запустите приложение (можно указать `SSL_CERT` и `SSL_KEY` для HTTPS):
+8. Запустите приложение (можно указать `SSL_CERT` и `SSL_KEY` для HTTPS):
    ```bash
    python run.py
    ```
-8. Запустите воркер очереди (требуется Redis):
+9. Запустите воркер очереди (требуется Redis):
    ```bash
    python run_worker.py
    ```
    Адрес Redis можно задать через переменную `REDIS_URL` (по умолчанию
    используется `redis://localhost:6379/0`).
-9. Логи сервера пишутся в файл `airservice.log` в формате JSON и содержат поля
+10. Логи сервера пишутся в файл `airservice.log` в формате JSON и содержат поля
    `timestamp`, `user`, `endpoint` и `message`.
-10. При изменении переводов выполните команду
+11. При изменении переводов выполните команду
     `pybabel compile -d airservice/translations` для сборки `.mo`‑файлов.
 
 ### Troubleshooting

--- a/airservice/app.py
+++ b/airservice/app.py
@@ -1,4 +1,6 @@
 from flask import Flask, request, g, has_request_context
+from flask.cli import with_appcontext
+from flask import current_app
 import logging
 import os
 from datetime import datetime, timezone
@@ -83,6 +85,13 @@ def create_app(config_object=None):
     app.register_blueprint(orders_bp)
     app.register_blueprint(admin_bp, url_prefix='/admin')
     app.register_blueprint(integration_bp)
+
+    @app.cli.command('seed-data')
+    @with_appcontext
+    def seed_data():
+        """Load demo categories, items and orders."""
+        from .sample_data import load_demo_data
+        load_demo_data(current_app)
 
     @app.route('/')
     def index():

--- a/airservice/sample_data.py
+++ b/airservice/sample_data.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from .models import db, Category, Item, Order, OrderItem
+
+
+def load_demo_data(app):
+    """Insert demo categories, items and orders if tables are empty."""
+    with app.app_context():
+        if Category.query.first() is None and Item.query.first() is None:
+            cats = {
+                'Food': Category(name='Food'),
+                'Drinks': Category(name='Drinks'),
+                'Accessories': Category(name='Accessories'),
+                'Services': Category(name='Services'),
+            }
+            cats['Alcohol'] = Category(name='Alcohol', parent=cats['Drinks'])
+            db.session.add_all(cats.values())
+            db.session.flush()
+
+            items = [
+                Item(name='Sandwich', price=5.0, category=cats['Food']),
+                Item(name='Salad', price=7.0, category=cats['Food']),
+                Item(name='Water', price=1.5, category=cats['Drinks']),
+                Item(name='Wine', price=8.0, category=cats['Alcohol']),
+                Item(name='Coffee', price=3.0, category=cats['Drinks']),
+                Item(name='Blanket', price=15.0, category=cats['Accessories']),
+                Item(name='Headphones', price=25.0, category=cats['Accessories']),
+                Item(name='WiFi', price=10.0, is_service=True, category=cats['Services']),
+                Item(name='Priority Boarding', price=12.0, is_service=True, category=cats['Services']),
+            ]
+            db.session.add_all(items)
+            db.session.commit()
+
+        if Order.query.first() is None:
+            goods_list = [
+                Item.query.filter_by(name='Sandwich').first().id,
+                Item.query.filter_by(name='Water').first().id,
+                Item.query.filter_by(name='Blanket').first().id,
+            ]
+            service_list = [
+                Item.query.filter_by(name='WiFi').first().id,
+                Item.query.filter_by(name='Priority Boarding').first().id,
+            ]
+            for year in [2021, 2022, 2023]:
+                for month in range(1, 13):
+                    for num in range(5):
+                        order = Order(
+                            seat=f"{month}{num}A",
+                            status='done',
+                            created_at=datetime(year, month, 15),
+                            payment_method='card'
+                        )
+                        db.session.add(order)
+                        db.session.flush()
+                        g_id = goods_list[num % len(goods_list)]
+                        s_id = service_list[num % len(service_list)]
+                        db.session.add(OrderItem(order_id=order.id, item_id=g_id, quantity=1))
+                        db.session.add(OrderItem(order_id=order.id, item_id=s_id, quantity=1))
+            db.session.commit()


### PR DESCRIPTION
## Summary
- insert demo catalog and orders with `load_demo_data`
- expose `flask seed-data` CLI command
- document running `flask seed-data` after migrations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846788611ac8331bd080fc9952bbd3a