### PR TITLE
Prefill seat number in cart

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -180,7 +180,11 @@ const MainTabNavigator = ({ seatNumber }: { seatNumber: string }) => {
       })}
     >
       <Tab.Screen name={t('navigation.catalog')} component={CatalogScreen} />
-      <Tab.Screen name={t('navigation.cart')} component={CartScreen} />
+      <Tab.Screen
+        name={t('navigation.cart')}
+        component={CartScreen}
+        initialParams={{ seatNumber }}
+      />
       <Tab.Screen
         name={t('navigation.profile')}
         component={ProfileScreen}

--- a/frontend/src/screens/CartScreen.tsx
+++ b/frontend/src/screens/CartScreen.tsx
@@ -24,7 +24,7 @@ const CartScreen = ({ navigation, route }: any) => {
       price: 599,
     },
   ]);
-  const [seatNumber, setSeatNumber] = useState('');
+  const [seatNumber, setSeatNumber] = useState(route.params?.seatNumber || '');
   const [loading, setLoading] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
 


### PR DESCRIPTION
## Summary
- auto-fill seat number for cart tab
- initialize cart seat field from navigation params

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846789dcf808331a34bac3f8b8d3589