### PR TITLE
Clarify EXPO_PUBLIC_API_URL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ python run_worker.py  # REDIS_URL задаёт адрес Redis
 # установка зависимостей и сборка web-версии
 cd frontend
 npm install
-npm run web-build
+EXPO_PUBLIC_API_URL=http://192.168.x.x:5000 npm run web-build
 
 # в режиме разработки
 EXPO_PUBLIC_API_URL=http://localhost:5000 npm start
 EXPO_PUBLIC_API_URL=http://192.168.178.20:5000 npm start
 ```
+
+При сборке переменная `EXPO_PUBLIC_API_URL` обязательна, иначе URL бэкенда остаётся `http://localhost:5000`.
 
 По умолчанию статические файлы из `frontend/web-build` раздаются Flask-приложением. Для мобильных платформ Expo предоставляет эмуляторы и возможность публикации.
 


### PR DESCRIPTION
## Summary
- document that `EXPO_PUBLIC_API_URL` must be set when using `npm run web-build`
- show example `EXPO_PUBLIC_API_URL=http://192.168.x.x:5000 npm run web-build`
- note default backend URL remains `http://localhost:5000` when unset

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d51c0e2c833197ca4fb29541c55c