### PR TITLE
Add image thumbnail support in cart

### DIFF
--- a/frontend/src/screens/CartScreen.tsx
+++ b/frontend/src/screens/CartScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, StyleSheet, ScrollView, Modal } from 'react-native';
+import { View, StyleSheet, ScrollView, Modal, Image } from 'react-native';
 import { Card, Button, Text, TextInput, Divider, useTheme } from 'react-native-paper';
 import { OrderItem, PaymentMethod } from '../types';
 import PaymentForm from '../components/PaymentForm';
@@ -109,6 +109,14 @@ const CartScreen = ({ navigation, route }: any) => {
               <Card key={item.productId} style={[styles.card, { backgroundColor: theme.colors.surface }]}>
                 <Card.Content>
                   <View style={styles.itemRow}>
+                    <Image
+                      style={styles.itemImage}
+                      source={
+                        item.image
+                          ? { uri: item.image }
+                          : require('../assets/icon.png')
+                      }
+                    />
                     <View style={styles.itemInfo}>
                       <Text style={[styles.itemName, { color: theme.colors.onSurface }]}>{item.name}</Text>
                       <Text style={[styles.itemPrice, { color: theme.colors.onSurfaceVariant }]}>
@@ -242,6 +250,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  itemImage: {
+    width: 50,
+    height: 50,
+    marginRight: 10,
+    borderRadius: 4,
   },
   itemInfo: {
     flex: 1,

--- a/frontend/src/screens/ProductDetailsScreen.tsx
+++ b/frontend/src/screens/ProductDetailsScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, StyleSheet, ScrollView, Image, TouchableOpacity } from 'react-native';
 import { Button, Text, Card, Snackbar, Divider, List, useTheme } from 'react-native-paper';
 import { MaterialCommunityIcon } from '../components/CustomIcons';
-import { Product } from '../types';
+import { Product, OrderItem } from '../types';
 import { useTranslation } from 'react-i18next';
 
 const ProductDetailsScreen = ({ route, navigation }: any) => {
@@ -23,10 +23,18 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
     // In a real app, this would dispatch to a cart state manager or context
     // For now, we'll just show a snackbar
     setSnackbarVisible(true);
-    
+
+    const item: OrderItem = {
+      productId: product.id,
+      name: product.name,
+      price: product.price,
+      quantity,
+      image: product.image,
+    };
+
     // Navigate back to catalog after a short delay
     setTimeout(() => {
-      navigation.navigate('Cart');
+      navigation.navigate('Cart', { newItem: item });
     }, 1500);
   };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,6 +49,7 @@ export interface OrderItem {
   quantity: number;
   price: number;
   name: string;
+  image?: string;
 }
 
 export enum OrderStatus {


### PR DESCRIPTION
## Summary
- extend `OrderItem` with optional image field
- include product image when adding item to cart
- display thumbnail in CartScreen
- style cart item images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e85a5d188331b43ec045774e27d3