### PR TITLE
Fix sample data to use all repo images

### DIFF
--- a/airservice/sample_data.py
+++ b/airservice/sample_data.py
@@ -12,42 +12,77 @@ def load_demo_data(app):
                 "Drinks": Category(name="Drinks", image="categories/drinks.jpg"),
                 "Accessories": Category(name="Accessories", image="categories/accessories.jpg"),
                 "Services": Category(name="Services", image="categories/services.jpg"),
+                "Snacks": Category(name="Snacks", image="categories/snacks.jpg"),
+                "Desserts": Category(name="Desserts", image="categories/desserts.jpg"),
+                "Cosmetics": Category(name="Cosmetics", image="categories/cosmetics.jpg"),
+                "Toys": Category(name="Toys", image="categories/toys.jpg"),
+                "Books": Category(name="Books", image="categories/books.jpg"),
+                "Parfumes": Category(name="Parfumes", image="categories/parfumes.jpg"),
             }
+            # add a subcategory for hierarchy demo
+            cats["Alcohol"] = Category(
+                name="Alcohol",
+                parent=cats["Drinks"],
+                image="categories/alcohol.jpg",
+            )
             db.session.add_all(cats.values())
             db.session.flush()
 
+            items_data = [
+                ("Куриное филе с овощами", "Нежное куриное филе, приготовленное на гриле, подается с сезонными овощами и соусом.", 750.0, "Food", "products/chicken_filet.jpg"),
+                ("Паста Карбонара", "Классическая итальянская паста с соусом из сливок, яиц, бекона и сыра пармезан.", 680.0, "Food", "products/carbonara.jpg"),
+                ("Стейк из говядины", "Сочный стейк из мраморной говядины средней прожарки с картофельным пюре и соусом.", 1200.0, "Food", "products/marbled_beef.jpg"),
+                ("Рыба с овощами на пару", "Нежное филе лосося, приготовленное на пару, с овощным гарниром и лимонным соусом.", 850.0, "Food", "products/steamed_fish.jpg"),
+                ("Вегетарианский салат", "Свежий салат из сезонных овощей с оливковым маслом и бальзамическим уксусом.", 450.0, "Food", "products/vegeterian_salad.jpg"),
+                ("Борщ", "Традиционный украинский борщ со сметаной и чесночными пампушками.", 480.0, "Food", "products/borsch.jpg"),
+                ("Свежевыжатый апельсиновый сок", "Натуральный свежевыжатый сок из спелых апельсинов.", 350.0, "Drinks", "products/orange_juice.jpg"),
+                ("Минеральная вода", "Негазированная минеральная вода.", 150.0, "Drinks", "products/mineral_water_no_gas.jpg"),
+                ("Кофе Американо", "Классический кофе американо из свежемолотых зерен арабики.", 280.0, "Drinks", "products/americano_coffee.jpg"),
+                ("Чай зеленый", "Китайский зеленый чай с жасмином.", 220.0, "Drinks", "products/green_tea.jpg"),
+                ("Смузи ягодный", "Освежающий смузи из свежих ягод с йогуртом и медом.", 380.0, "Drinks", "products/smoozi.jpg"),
+                ("Вино красное сухое", "Итальянское красное сухое вино Кьянти Классико.", 750.0, "Alcohol", "products/red_wine.jpg"),
+                ("Пиво светлое", "Чешское светлое пиво Пилзнер.", 450.0, "Alcohol", "products/beer_white.jpg"),
+                ("Виски", "Шотландский односолодовый виски 12 лет выдержки.", 950.0, "Alcohol", "products/whiskey.jpg"),
+                ("Орешки ассорти", "Смесь жареных орехов с солью.", 320.0, "Snacks", "products/nuts_assorty.jpg"),
+                ("Чипсы картофельные", "Хрустящие картофельные чипсы с солью и специями.", 280.0, "Snacks", "products/potato_chips.jpg"),
+                ("Сырная тарелка", "Ассорти из 4 видов сыра с виноградом и крекерами.", 680.0, "Snacks", "products/cheese_plate.jpg"),
+                ("Тирамису", "Классический итальянский десерт на основе маскарпоне и кофе.", 420.0, "Desserts", "products/tiramisu.jpg"),
+                ("Чизкейк", "Нежный чизкейк с ягодным соусом.", 390.0, "Desserts", "products/raspberry_cheesecake.jpg"),
+                ("Шоколадный фондан", "Шоколадный кекс с жидкой начинкой и ванильным мороженым.", 450.0, "Desserts", "products/chocolate_fondan.jpg"),
+                ("Дорожная подушка", "Удобная подушка для шеи для комфортного сна во время полета.", 980.0, "Accessories", "products/travel_pillow.jpg"),
+                ("Маска для сна", "Мягкая маска для сна с регулируемым ремешком.", 450.0, "Accessories", "products/sleep_mask.jpg"),
+                ("Беруши", "Силиконовые беруши для защиты от шума.", 280.0, "Accessories", "products/ear_plugs.jpg"),
+                ("Наушники", "Беспроводные наушники с шумоподавлением.", 3500.0, "Accessories", "products/wireless_headphones.jpg"),
+                ("Увлажняющий крем", "Увлажняющий крем для лица с гиалуроновой кислотой.", 850.0, "Cosmetics", "products/soothening_cream.jpg"),
+                ("Набор миниатюр", "Дорожный набор миниатюр средств по уходу за кожей.", 1200.0, "Cosmetics", "products/miniatur_set.jpg"),
+                ("Мягкая игрушка", "Мягкая игрушка в виде самолета для детей.", 680.0, "Toys", "products/soft_toy.jpg"),
+                ("Набор для раскрашивания", "Детский набор для раскрашивания с карандашами и раскрасками.", 450.0, "Toys", "products/safe_paint_set.jpg"),
+                ("Роман \"Мастер и Маргарита\"", "Знаменитый роман Михаила Булгакова в мягкой обложке.", 550.0, "Books", "products/master_and_margarita.jpg"),
+                ("Журнал о путешествиях", "Свежий выпуск журнала о путешествиях и приключениях.", 320.0, "Books", "products/travel_journal.jpg"),
+                ("WiFi", "Доступ к Wi-Fi во время полета.", 10.0, "Services", "products/internet_wi-fi.jpg", True),
+            ]
             items = [
-                Item(name="Sandwich", price=5.0, category=cats["Food"], image="products/sandwich.jpg"),
-                Item(name="Salad", price=7.0, category=cats["Food"], image="products/salad.jpg"),
-                Item(name="Water", price=1.5, category=cats["Drinks"], image="products/water.jpg"),
-                Item(name="Wine", price=8.0, category=cats["Alcohol"], image="products/wine.jpg"),
-                Item(name="Coffee", price=3.0, category=cats["Drinks"], image="products/coffee.jpg"),
-                Item(name="Blanket", price=15.0, category=cats["Accessories"], image="products/blanket.jpg"),
-                Item(name="Headphones", price=25.0, category=cats["Accessories"], image="products/headphones.jpg"),
                 Item(
-                    name="WiFi", price=10.0, is_service=True, category=cats["Services"], image="products/wifi.jpg"
-                ),
-                Item(
-                    name="Priority Boarding",
-                    image="priority_boarding.png",
-                    price=12.0,
-                    is_service=True,
-                    category=cats["Services"],
-                    image="products/priority.jpg",
-                ),
+                    name=name,
+                    description=desc,
+                    price=price,
+                    category=cats[cat],
+                    image=image,
+                    is_service=(rest[0] if rest else False),
+                )
+                for name, desc, price, cat, image, *rest in items_data
             ]
             db.session.add_all(items)
             db.session.commit()
 
         if Order.query.first() is None:
             goods_list = [
-                Item.query.filter_by(name="Sandwich").first().id,
-                Item.query.filter_by(name="Water").first().id,
-                Item.query.filter_by(name="Blanket").first().id,
+                Item.query.filter_by(name="Паста Карбонара").first().id,
+                Item.query.filter_by(name="Минеральная вода").first().id,
+                Item.query.filter_by(name="Вегетарианский салат").first().id,
             ]
             service_list = [
                 Item.query.filter_by(name="WiFi").first().id,
-                Item.query.filter_by(name="Priority Boarding").first().id,
             ]
 
             demo_dates = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,21 +57,53 @@ def sample_data(app):
             'Drinks': Category(name='Drinks', image='categories/drinks.jpg'),
             'Accessories': Category(name='Accessories', image='categories/accessories.jpg'),
             'Services': Category(name='Services', image='categories/services.jpg'),
+            'Snacks': Category(name='Snacks', image='categories/snacks.jpg'),
+            'Desserts': Category(name='Desserts', image='categories/desserts.jpg'),
+            'Cosmetics': Category(name='Cosmetics', image='categories/cosmetics.jpg'),
+            'Toys': Category(name='Toys', image='categories/toys.jpg'),
+            'Books': Category(name='Books', image='categories/books.jpg'),
+            'Parfumes': Category(name='Parfumes', image='categories/parfumes.jpg'),
         }
         # subcategory for hierarchy tests
         cats['Alcohol'] = Category(name='Alcohol', parent=cats['Drinks'], image='categories/alcohol.jpg')
         db.session.add_all(cats.values())
         db.session.flush()
+        items_data = [
+            ('Куриное филе с овощами', 750.0, 'Food', 'products/chicken_filet.jpg'),
+            ('Паста Карбонара', 680.0, 'Food', 'products/carbonara.jpg'),
+            ('Стейк из говядины', 1200.0, 'Food', 'products/marbled_beef.jpg'),
+            ('Рыба с овощами на пару', 850.0, 'Food', 'products/steamed_fish.jpg'),
+            ('Вегетарианский салат', 450.0, 'Food', 'products/vegeterian_salad.jpg'),
+            ('Борщ', 480.0, 'Food', 'products/borsch.jpg'),
+            ('Свежевыжатый апельсиновый сок', 350.0, 'Drinks', 'products/orange_juice.jpg'),
+            ('Минеральная вода', 150.0, 'Drinks', 'products/mineral_water_no_gas.jpg'),
+            ('Кофе Американо', 280.0, 'Drinks', 'products/americano_coffee.jpg'),
+            ('Чай зеленый', 220.0, 'Drinks', 'products/green_tea.jpg'),
+            ('Смузи ягодный', 380.0, 'Drinks', 'products/smoozi.jpg'),
+            ('Вино красное сухое', 750.0, 'Alcohol', 'products/red_wine.jpg'),
+            ('Пиво светлое', 450.0, 'Alcohol', 'products/beer_white.jpg'),
+            ('Виски', 950.0, 'Alcohol', 'products/whiskey.jpg'),
+            ('Орешки ассорти', 320.0, 'Snacks', 'products/nuts_assorty.jpg'),
+            ('Чипсы картофельные', 280.0, 'Snacks', 'products/potato_chips.jpg'),
+            ('Сырная тарелка', 680.0, 'Snacks', 'products/cheese_plate.jpg'),
+            ('Тирамису', 420.0, 'Desserts', 'products/tiramisu.jpg'),
+            ('Чизкейк', 390.0, 'Desserts', 'products/raspberry_cheesecake.jpg'),
+            ('Шоколадный фондан', 450.0, 'Desserts', 'products/chocolate_fondan.jpg'),
+            ('Дорожная подушка', 980.0, 'Accessories', 'products/travel_pillow.jpg'),
+            ('Маска для сна', 450.0, 'Accessories', 'products/sleep_mask.jpg'),
+            ('Беруши', 280.0, 'Accessories', 'products/ear_plugs.jpg'),
+            ('Наушники', 3500.0, 'Accessories', 'products/wireless_headphones.jpg'),
+            ('Увлажняющий крем', 850.0, 'Cosmetics', 'products/soothening_cream.jpg'),
+            ('Набор миниатюр', 1200.0, 'Cosmetics', 'products/miniatur_set.jpg'),
+            ('Мягкая игрушка', 680.0, 'Toys', 'products/soft_toy.jpg'),
+            ('Набор для раскрашивания', 450.0, 'Toys', 'products/safe_paint_set.jpg'),
+            ('Роман "Мастер и Маргарита"', 550.0, 'Books', 'products/master_and_margarita.jpg'),
+            ('Журнал о путешествиях', 320.0, 'Books', 'products/travel_journal.jpg'),
+            ('WiFi', 10.0, 'Services', 'products/internet_wi-fi.jpg', True),
+        ]
         items = [
-            Item(name='Sandwich', price=5.0, category=cats['Food'], image='products/sandwich.jpg'),
-            Item(name='Salad', price=7.0, category=cats['Food'], image='products/salad.jpg'),
-            Item(name='Water', price=1.5, category=cats['Drinks'], image='products/water.jpg'),
-            Item(name='Wine', price=8.0, category=cats['Alcohol'], image='products/wine.jpg'),
-            Item(name='Coffee', price=3.0, category=cats['Drinks'], image='products/coffee.jpg'),
-            Item(name='Blanket', price=15.0, category=cats['Accessories'], image='products/blanket.jpg'),
-            Item(name='Headphones', price=25.0, category=cats['Accessories'], image='products/headphones.jpg'),
-            Item(name='WiFi', price=10.0, is_service=True, category=cats['Services'], image='products/wifi.jpg'),
-            Item(name='Priority Boarding', price=12.0, is_service=True, category=cats['Services'], image='products/priority.jpg'),
+            Item(name=name, price=price, category=cats[cat], image=image, is_service=(rest[0] if rest else False))
+            for name, price, cat, image, *rest in items_data
         ]
         db.session.add_all(items)
         db.session.commit()
@@ -87,13 +119,12 @@ def populate_orders(app, sample_data):
     """Create 5 varied orders per month for 3 years."""
     with app.app_context():
         goods_list = [
-            sample_data['items']['Sandwich'],
-            sample_data['items']['Water'],
-            sample_data['items']['Blanket'],
+            sample_data['items']['Паста Карбонара'],
+            sample_data['items']['Минеральная вода'],
+            sample_data['items']['Вегетарианский салат'],
         ]
         service_list = [
             sample_data['items']['WiFi'],
-            sample_data['items']['Priority Boarding'],
         ]
         for year in [2021, 2022, 2023]:
             for month in range(1, 13):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -65,21 +65,21 @@ def test_sales_report_multiple_years(client, populate_orders):
     rv = client.get('/admin/reports/sales?year=2022', headers=auth_header())
     data = rv.get_json()
     assert len(data) == 12
-    assert data['2022-01']['goods'] == 28.0
-    assert data['2022-01']['services'] == 54.0
+    assert data['2022-01']['goods'] == 2110.0
+    assert data['2022-01']['services'] == 50.0
 
     rv = client.get('/admin/reports/sales?year=2023', headers=auth_header())
     data = rv.get_json()
-    assert data['2023-12']['goods'] == 28.0
-    assert data['2023-12']['services'] == 54.0
+    assert data['2023-12']['goods'] == 2110.0
+    assert data['2023-12']['services'] == 50.0
 
 
 def test_sales_report_all_years(client, populate_orders):
     rv = client.get('/admin/reports/sales', headers=auth_header())
     data = rv.get_json()
     assert len(data) == 36
-    assert data['2021-01']['goods'] == 28.0
-    assert data['2023-12']['services'] == 54.0
+    assert data['2021-01']['goods'] == 2110.0
+    assert data['2023-12']['services'] == 50.0
 
 
 def test_admin_requires_auth(client):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -28,7 +28,7 @@ def test_login_and_order_uses_account_seat(client, app, sample_data):
     assert data["seat"] == "5A"
     assert not data["is_admin"]
 
-    item_id = sample_data["items"]["Sandwich"]
+    item_id = sample_data["items"]["Паста Карбонара"]
     rv = client.post(
         "/orders",
         json={"items": [{"item_id": item_id}]},

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -7,48 +7,82 @@ def test_catalog_filters(client, sample_data):
     rv = client.get('/catalog')
     assert rv.status_code == 200
     data = rv.get_json()
-    assert len(data) == 9
+    assert len(data) == 31
     # ensure category name, id and image are present
     assert {'category', 'category_id', 'image'} <= set(data[0].keys())
 
     # by category
     food_cat = sample_data['categories']['Food']
     rv = client.get(f'/catalog?category={food_cat}')
-    assert {i['name'] for i in rv.get_json()} == {'Sandwich', 'Salad'}
+    assert {i['name'] for i in rv.get_json()} == {
+        'Куриное филе с овощами',
+        'Паста Карбонара',
+        'Стейк из говядины',
+        'Рыба с овощами на пару',
+        'Вегетарианский салат',
+        'Борщ',
+    }
 
     # service items only
     rv = client.get('/catalog?service=1')
     names = {i['name'] for i in rv.get_json()}
-    assert names == {'WiFi', 'Priority Boarding'}
+    assert names == {'WiFi'}
 
     # search by name
-    rv = client.get('/catalog?q=head')
-    assert rv.get_json()[0]['name'] == 'Headphones'
+    rv = client.get('/catalog?q=wifi')
+    assert rv.get_json()[0]['name'] == 'WiFi'
 
 
 def test_catalog_availability_filter(client, sample_data):
-    wine_id = sample_data['items']['Wine']
+    wine_id = sample_data['items']['Вино красное сухое']
     client.put(f'/admin/items/{wine_id}', json={'available': False}, headers=auth_header())
     rv = client.get('/catalog?available=1')
     names = {i['name'] for i in rv.get_json()}
-    assert 'Wine' not in names
+    assert 'Вино красное сухое' not in names
     rv = client.get('/catalog?available=0')
     names = {i['name'] for i in rv.get_json()}
-    assert 'Wine' in names
+    assert 'Вино красное сухое' in names
 
 
 def test_catalog_price_and_service_filters(client, sample_data):
-    rv = client.get('/catalog?price_min=5&price_max=10')
+    rv = client.get('/catalog?price_min=100&price_max=800')
     assert rv.status_code == 200
     data = rv.get_json()
     names = {i['name'] for i in data}
-    assert names == {'Sandwich', 'Salad', 'Wine', 'WiFi'}
+    assert names == {
+        'Беруши', 'Борщ', 'Вегетарианский салат', 'Вино красное сухое',
+        'Журнал о путешествиях', 'Кофе Американо', 'Куриное филе с овощами',
+        'Маска для сна', 'Минеральная вода', 'Мягкая игрушка',
+        'Набор для раскрашивания', 'Орешки ассорти', 'Паста Карбонара',
+        'Пиво светлое', 'Роман "Мастер и Маргарита"', 'Свежевыжатый апельсиновый сок',
+        'Смузи ягодный', 'Сырная тарелка', 'Тирамису', 'Чай зеленый',
+        'Чизкейк', 'Чипсы картофельные', 'Шоколадный фондан'
+    }
     prices = {i['name']: i['price'] for i in data}
     assert prices == {
-        'Sandwich': 5.0,
-        'Salad': 7.0,
-        'Wine': 8.0,
-        'WiFi': 10.0,
+        'Беруши': 280.0,
+        'Борщ': 480.0,
+        'Вегетарианский салат': 450.0,
+        'Вино красное сухое': 750.0,
+        'Журнал о путешествиях': 320.0,
+        'Кофе Американо': 280.0,
+        'Куриное филе с овощами': 750.0,
+        'Маска для сна': 450.0,
+        'Минеральная вода': 150.0,
+        'Мягкая игрушка': 680.0,
+        'Набор для раскрашивания': 450.0,
+        'Орешки ассорти': 320.0,
+        'Паста Карбонара': 680.0,
+        'Пиво светлое': 450.0,
+        'Роман "Мастер и Маргарита"': 550.0,
+        'Свежевыжатый апельсиновый сок': 350.0,
+        'Смузи ягодный': 380.0,
+        'Сырная тарелка': 680.0,
+        'Тирамису': 420.0,
+        'Чай зеленый': 220.0,
+        'Чизкейк': 390.0,
+        'Чипсы картофельные': 280.0,
+        'Шоколадный фондан': 450.0,
     }
 
     rv = client.get('/catalog?service=0')
@@ -56,13 +90,36 @@ def test_catalog_price_and_service_filters(client, sample_data):
     data = rv.get_json()
     prices = {i['name']: i['price'] for i in data}
     assert prices == {
-        'Sandwich': 5.0,
-        'Salad': 7.0,
-        'Water': 1.5,
-        'Wine': 8.0,
-        'Coffee': 3.0,
-        'Blanket': 15.0,
-        'Headphones': 25.0,
+        'Куриное филе с овощами': 750.0,
+        'Паста Карбонара': 680.0,
+        'Стейк из говядины': 1200.0,
+        'Рыба с овощами на пару': 850.0,
+        'Вегетарианский салат': 450.0,
+        'Борщ': 480.0,
+        'Свежевыжатый апельсиновый сок': 350.0,
+        'Минеральная вода': 150.0,
+        'Кофе Американо': 280.0,
+        'Чай зеленый': 220.0,
+        'Смузи ягодный': 380.0,
+        'Вино красное сухое': 750.0,
+        'Пиво светлое': 450.0,
+        'Виски': 950.0,
+        'Орешки ассорти': 320.0,
+        'Чипсы картофельные': 280.0,
+        'Сырная тарелка': 680.0,
+        'Тирамису': 420.0,
+        'Чизкейк': 390.0,
+        'Шоколадный фондан': 450.0,
+        'Дорожная подушка': 980.0,
+        'Маска для сна': 450.0,
+        'Беруши': 280.0,
+        'Наушники': 3500.0,
+        'Увлажняющий крем': 850.0,
+        'Набор миниатюр': 1200.0,
+        'Мягкая игрушка': 680.0,
+        'Набор для раскрашивания': 450.0,
+        'Роман "Мастер и Маргарита"': 550.0,
+        'Журнал о путешествиях': 320.0,
     }
 
 

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -2,7 +2,7 @@ from conftest import auth_header
 
 
 def test_order_flow_and_idempotency(client, sample_data):
-    item_id = sample_data['items']['Sandwich']
+    item_id = sample_data['items']['Паста Карбонара']
     payload = {
         'seat': '10B',
         'items': [{'item_id': item_id, 'quantity': 2}],
@@ -21,9 +21,9 @@ def test_order_flow_and_idempotency(client, sample_data):
     assert rv.status_code == 200
     data = rv.get_json()
     assert data['seat'] == '10B'
-    assert data['total'] == 10.0
+    assert data['total'] == 1360.0
     assert data['items'][0]['item_id'] == item_id
-    assert data['items'][0]['price'] == 5.0
+    assert data['items'][0]['price'] == 680.0
 
     rv = client.patch(f'/admin/orders/{order_id}', json={'status': 'done'}, headers=auth_header())
     assert rv.status_code == 200
@@ -46,7 +46,7 @@ def test_create_order_rejects_invalid_items(client, sample_data):
     payload = {
         'seat': '22B',
         'items': [
-            {'item_id': sample_data['items']['Sandwich']},
+            {'item_id': sample_data['items']['Паста Карбонара']},
             {'item_id': bad_id},
         ],
     }
@@ -55,7 +55,7 @@ def test_create_order_rejects_invalid_items(client, sample_data):
 
 
 def test_update_order_status_validation(client, sample_data):
-    item_id = sample_data['items']['Sandwich']
+    item_id = sample_data['items']['Паста Карбонара']
     rv = client.post('/orders', json={'seat': '15C', 'items': [{'item_id': item_id}], 'payment_method': 'cash'})
     assert rv.status_code == 201
     order_id = rv.get_json()['order_id']
@@ -68,7 +68,7 @@ def test_update_order_status_validation(client, sample_data):
 
 
 def test_list_orders_filters(client, sample_data):
-    item_id = sample_data['items']['Sandwich']
+    item_id = sample_data['items']['Паста Карбонара']
     rv = client.post('/orders', json={'seat': '5A', 'items': [{'item_id': item_id}]})
     first = rv.get_json()['order_id']
     rv = client.post('/orders', json={'seat': '5A', 'items': [{'item_id': item_id}]})
@@ -80,14 +80,14 @@ def test_list_orders_filters(client, sample_data):
     assert rv.status_code == 200
     data = rv.get_json()
     assert [o['id'] for o in data] == [first, second]
-    assert all(o['total'] == 5.0 for o in data)
+    assert all(o['total'] == 680.0 for o in data)
     assert all(o['items'][0]['item_id'] == item_id for o in data)
 
     rv = client.get('/orders?seat=5A&status=done')
     assert rv.status_code == 200
     data = rv.get_json()
     assert len(data) == 1 and data[0]['id'] == second
-    assert data[0]['total'] == 5.0
+    assert data[0]['total'] == 680.0
 
     rv = client.get('/orders')
     assert rv.status_code == 400

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,7 +5,7 @@ from airservice.models import db, Item
 
 
 def test_order_service_create_and_idempotent(app, sample_data):
-    item_id = sample_data['items']['Sandwich']
+    item_id = sample_data['items']['Паста Карбонара']
     items = [{'item_id': item_id, 'quantity': 1}]
     with app.app_context():
         with patch('airservice.services.order_service.push_event') as pe:
@@ -19,7 +19,7 @@ def test_order_service_create_and_idempotent(app, sample_data):
 
 
 def test_update_order_status(app, sample_data):
-    item_id = sample_data['items']['Sandwich']
+    item_id = sample_data['items']['Паста Карбонара']
     with app.app_context():
         order, _ = order_service.create_order('2A', [{'item_id': item_id}], payment_method='cash', idempotency_key=None)
         with patch('airservice.services.order_service.push_event') as pe:


### PR DESCRIPTION
## Summary
- populate demo categories for every category image
- load all product images into sample data
- mirror the expanded dataset in test fixtures
- update catalog tests for new items

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848fb1aacfc8331a7aa985a43a1677c