### PR TITLE
Use translation keys for cart/catalog navigation

### DIFF
--- a/frontend/src/screens/CartScreen.tsx
+++ b/frontend/src/screens/CartScreen.tsx
@@ -89,7 +89,7 @@ const CartScreen = ({ navigation, route }: any) => {
               <Text style={[styles.emptyText, { color: theme.colors.onSurface }]}>{t('cart.empty')}</Text>
               <Button
                 mode="contained"
-                onPress={() => navigation.navigate('Catalog')}
+                onPress={() => navigation.navigate(t('navigation.catalog'))}
                 style={styles.shopButton}
                 buttonColor={theme.colors.primary}
                 textColor={theme.colors.onPrimary}

--- a/frontend/src/screens/OrderHistoryScreen.tsx
+++ b/frontend/src/screens/OrderHistoryScreen.tsx
@@ -212,9 +212,9 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
           <Text style={{ color: theme.colors.onBackground }}>
             {t('orderStatus.noOrders')}
           </Text>
-          <Button 
-            mode="contained" 
-            onPress={() => navigation.navigate('Catalog')}
+          <Button
+            mode="contained"
+            onPress={() => navigation.navigate(t('navigation.catalog'))}
             style={styles.catalogButton}
             buttonColor={theme.colors.primary}
             textColor={theme.colors.onPrimary}

--- a/frontend/src/screens/OrderStatusScreen.tsx
+++ b/frontend/src/screens/OrderStatusScreen.tsx
@@ -107,7 +107,7 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
         <Text style={{ color: theme.colors.onBackground }}>{t('orderStatus.orderNotFound')}</Text>
         <Button
           mode="contained"
-          onPress={() => navigation.navigate('Catalog')}
+          onPress={() => navigation.navigate(t('navigation.catalog'))}
           style={styles.button}
           buttonColor={theme.colors.primary}
           textColor={theme.colors.onPrimary}
@@ -175,7 +175,7 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
       <View style={styles.buttonContainer}>
         <Button
           mode="contained"
-          onPress={() => navigation.navigate('Catalog')}
+          onPress={() => navigation.navigate(t('navigation.catalog'))}
           style={[styles.button, { flex: 1, marginRight: 8 }]}
           buttonColor={theme.colors.primary}
           textColor={theme.colors.onPrimary}

--- a/frontend/src/screens/ProductDetailsScreen.tsx
+++ b/frontend/src/screens/ProductDetailsScreen.tsx
@@ -34,7 +34,7 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
 
     // Navigate back to catalog after a short delay
     setTimeout(() => {
-      navigation.navigate('Cart', { newItem: item });
+      navigation.navigate(t('navigation.cart'), { newItem: item });
     }, 1500);
   };
 
@@ -186,7 +186,7 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
         duration={1500}
         action={{
           label: t('navigation.cart'),
-          onPress: () => navigation.navigate('Cart'),
+          onPress: () => navigation.navigate(t('navigation.cart')),
         }}
         style={{ backgroundColor: theme.colors.surfaceVariant }}
         theme={{


### PR DESCRIPTION
## Summary
- use translation key when navigating to Cart from product details
- localize Catalog navigation buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490d32024c8331b8592d00740a79fd