### PR TITLE
Use typed route constants

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import './i18n/i18n'; // Import i18n settings
 import { initLanguage } from './i18n/i18n';
 import MobileContainer from './components/MobileContainer';
 import DeepLinkHandler from './components/DeepLinkHandler';
+import RouteName from './navigation/routes';
 
 // Import screens
 import LoginScreen from './screens/LoginScreen';
@@ -77,14 +78,14 @@ const linking = {
       Login: 'login',
       MainApp: {
         screens: {
-          [encodeURI('Каталог товаров')]: 'catalog',
-          [encodeURI('Корзина')]: 'cart',
-          [encodeURI('Профиль')]: 'profile',
+          [RouteName.CATALOG]: 'catalog',
+          [RouteName.CART]: 'cart',
+          [RouteName.PROFILE]: 'profile',
         }
       },
       AdminRoot: {
         screens: {
-          [encodeURI('Админ-панель')]: 'admin'
+          [RouteName.ADMIN_PANEL]: 'admin'
         }
       },
       ProductDetails: 'product/:id',
@@ -105,9 +106,15 @@ const linking = {
   getStateFromPath: (path: string, options: any) => {
     // Проверяем, соответствует ли путь имени компонента
     const componentNames = [
-      'CatalogScreen', 'CartScreen', 'ProfileScreen', 'LoginScreen',
-      'AdminPanel', 'ProductDetailsScreen', 'OrderStatusScreen', 'PaymentScreen',
-      'OrderHistoryScreen'
+      RouteName.CATALOG_SCREEN,
+      RouteName.CART_SCREEN,
+      RouteName.PROFILE_SCREEN,
+      RouteName.LOGIN_SCREEN,
+      RouteName.ADMIN_PANEL,
+      RouteName.PRODUCT_DETAILS_SCREEN,
+      RouteName.ORDER_STATUS_SCREEN,
+      RouteName.PAYMENT_SCREEN,
+      RouteName.ORDER_HISTORY_SCREEN
     ];
     
     // Проверка на соответствие имени компонента
@@ -152,11 +159,11 @@ const MainTabNavigator = ({ seatNumber }: { seatNumber: string }) => {
         tabBarIcon: ({ focused, color, size }: { focused: boolean, color: string, size: number }) => {
           let iconName: any = 'home';
 
-          if (route.name === t('navigation.catalog')) {
+          if (route.name === RouteName.CATALOG) {
             iconName = focused ? 'fast-food' : 'fast-food-outline';
-          } else if (route.name === t('navigation.cart')) {
+          } else if (route.name === RouteName.CART) {
             iconName = focused ? 'cart' : 'cart-outline';
-          } else if (route.name === t('navigation.profile')) {
+          } else if (route.name === RouteName.PROFILE) {
             iconName = focused ? 'person' : 'person-outline';
           }
 
@@ -179,16 +186,22 @@ const MainTabNavigator = ({ seatNumber }: { seatNumber: string }) => {
         headerTintColor: defaultTheme.colors.onSurface,
       })}
     >
-      <Tab.Screen name={t('navigation.catalog')} component={CatalogScreen} />
       <Tab.Screen
-        name={t('navigation.cart')}
-        component={CartScreen}
-        initialParams={{ seatNumber }}
+        name={RouteName.CATALOG}
+        component={CatalogScreen}
+        options={{ title: t('navigation.catalog') }}
       />
       <Tab.Screen
-        name={t('navigation.profile')}
+        name={RouteName.CART}
+        component={CartScreen}
+        initialParams={{ seatNumber }}
+        options={{ title: t('navigation.cart') }}
+      />
+      <Tab.Screen
+        name={RouteName.PROFILE}
         component={ProfileScreen}
         initialParams={{ seatNumber }}
+        options={{ title: t('navigation.profile') }}
       />
     </Tab.Navigator>
   );
@@ -209,10 +222,10 @@ const AdminNavigator = () => {
         headerTintColor: defaultTheme.colors.onSurface,
       }}
     >
-      <Stack.Screen 
-        name={t('navigation.admin')} 
-        component={AdminPanel} 
-        options={{ headerShown: false }} 
+      <Stack.Screen
+        name={RouteName.ADMIN_PANEL}
+        component={AdminPanel}
+        options={{ headerShown: false, title: t('navigation.admin') }}
       />
     </Stack.Navigator>
   );
@@ -282,73 +295,73 @@ const RootStackNavigator = () => {
       />
       
       {/* Основные экраны приложения */}
-      <Stack.Screen name="MainApp" options={{ headerShown: false }}>
+      <Stack.Screen name={RouteName.MAIN_APP} options={{ headerShown: false }}>
         {() => <MainTabNavigator seatNumber={seatNumber} />}
       </Stack.Screen>
       
       {/* Админ-панель */}
-      <Stack.Screen 
-        name="AdminRoot" 
+      <Stack.Screen
+        name={RouteName.ADMIN_ROOT}
         component={AdminNavigator}
         options={{ headerShown: false }}
       />
       
       {/* Экраны доступные для всех */}
-      <Stack.Screen 
-        name="ProductDetails"
-        component={ProductDetailsScreen} 
+      <Stack.Screen
+        name={RouteName.PRODUCT_DETAILS}
+        component={ProductDetailsScreen}
         options={{ title: t('productDetails.title') }}
       />
-      <Stack.Screen 
-        name="OrderStatus"
-        component={OrderStatusScreen} 
+      <Stack.Screen
+        name={RouteName.ORDER_STATUS}
+        component={OrderStatusScreen}
         options={{ title: t('orderStatus.title') }}
       />
       
       {/* Прямой доступ к компонентам по их именам */}
-      <Stack.Screen 
-        name="CatalogScreen" 
-        component={CatalogScreen} 
+      <Stack.Screen
+        name={RouteName.CATALOG_SCREEN}
+        component={CatalogScreen}
         options={{ title: t('navigation.catalog') }}
       />
-      <Stack.Screen 
-        name="CartScreen" 
-        component={CartScreen} 
+      <Stack.Screen
+        name={RouteName.CART_SCREEN}
+        component={CartScreen}
         options={{ title: t('navigation.cart') }}
       />
       <Stack.Screen
-        name="ProfileScreen"
+        name={RouteName.PROFILE_SCREEN}
         component={ProfileScreen}
         options={{ title: t('navigation.profile') }}
         initialParams={{ seatNumber }}
       />
-      <Stack.Screen 
-        name="LoginScreen" 
-        component={LoginScreen} 
+      <Stack.Screen
+        name={RouteName.LOGIN_SCREEN}
+        component={LoginScreen}
         options={{ headerShown: false }}
       />
-      <Stack.Screen 
-        name="AdminPanel" 
-        component={AdminPanel} 
+      <Stack.Screen
+        name={RouteName.ADMIN_PANEL}
+        component={AdminPanel}
         options={{ title: t('navigation.admin') }}
       />
-      <Stack.Screen 
-        name="ProductDetailsScreen" 
-        component={ProductDetailsScreen} 
+      <Stack.Screen
+        name={RouteName.PRODUCT_DETAILS_SCREEN}
+        component={ProductDetailsScreen}
         options={{ title: t('productDetails.title') }}
       />
-      <Stack.Screen 
-        name="OrderStatusScreen" 
-        component={OrderStatusScreen} 
+      <Stack.Screen
+        name={RouteName.ORDER_STATUS_SCREEN}
+        component={OrderStatusScreen}
         options={{ title: t('orderStatus.title') }}
       />
-      <Stack.Screen 
-        name="PaymentScreen" 
-        component={PaymentScreen} 
+      <Stack.Screen
+        name={RouteName.PAYMENT_SCREEN}
+        component={PaymentScreen}
         options={{ title: t('payment.title') }}
       />
       <Stack.Screen
-        name="OrderHistoryScreen"
+        name={RouteName.ORDER_HISTORY_SCREEN}
         component={OrderHistoryScreen}
         options={{ title: t('navigation.orderHistory') }}
         initialParams={{ seatNumber }}

--- a/frontend/src/navigation/routes.ts
+++ b/frontend/src/navigation/routes.ts
@@ -1,0 +1,22 @@
+export enum RouteName {
+  LOGIN = 'Login',
+  MAIN_APP = 'MainApp',
+  ADMIN_ROOT = 'AdminRoot',
+  CATALOG = 'Catalog',
+  CART = 'Cart',
+  PROFILE = 'Profile',
+  ADMIN_PANEL = 'AdminPanel',
+  PRODUCT_DETAILS = 'ProductDetails',
+  ORDER_STATUS = 'OrderStatus',
+  CATALOG_SCREEN = 'CatalogScreen',
+  CART_SCREEN = 'CartScreen',
+  PROFILE_SCREEN = 'ProfileScreen',
+  LOGIN_SCREEN = 'LoginScreen',
+  PRODUCT_DETAILS_SCREEN = 'ProductDetailsScreen',
+  ORDER_STATUS_SCREEN = 'OrderStatusScreen',
+  PAYMENT_SCREEN = 'PaymentScreen',
+  ORDER_HISTORY_SCREEN = 'OrderHistoryScreen',
+  ORDER_DETAILS = 'OrderDetails'
+}
+
+export default RouteName;

--- a/frontend/src/screens/AdminPanel.tsx
+++ b/frontend/src/screens/AdminPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, ScrollView, Dimensions } from 'react-native';
 import { Card, Text, DataTable, Button, ActivityIndicator, Appbar } from 'react-native-paper';
 import { AnalyticsData, Order, OrderStatus } from '../types';
+import RouteName from '../navigation/routes';
 
 const AdminPanel = ({ navigation }: any) => {
   const [analyticsData, setAnalyticsData] = useState<AnalyticsData | null>(null);
@@ -142,9 +143,13 @@ const AdminPanel = ({ navigation }: any) => {
             </DataTable.Header>
 
             {analyticsData.recentOrders.map((order) => (
-              <DataTable.Row 
+              <DataTable.Row
                 key={order.id}
-                onPress={() => navigation.navigate('OrderDetails', { orderId: order.id })}
+                onPress={() =>
+                  navigation.navigate(RouteName.ORDER_DETAILS as never, {
+                    orderId: order.id,
+                  } as never)
+                }
               >
                 <DataTable.Cell>{order.id.substring(0, 8)}</DataTable.Cell>
                 <DataTable.Cell>{order.seatNumber}</DataTable.Cell>

--- a/frontend/src/screens/CartScreen.tsx
+++ b/frontend/src/screens/CartScreen.tsx
@@ -6,6 +6,7 @@ import PaymentForm from '../components/PaymentForm';
 import { useTranslation } from 'react-i18next';
 import DirectLinkButton from '../components/DirectLinkButton';
 import { createOrder } from '../api/api';
+import RouteName from '../navigation/routes';
 
 const CartScreen = ({ navigation, route }: any) => {
   const theme = useTheme();
@@ -68,7 +69,9 @@ const CartScreen = ({ navigation, route }: any) => {
       const res = await createOrder(payload);
       const orderId = res.order_id;
       setCartItems([]);
-      navigation.navigate('OrderStatus', { orderId: String(orderId) });
+      navigation.navigate(RouteName.ORDER_STATUS as never, {
+        orderId: String(orderId),
+      } as never);
     } catch (err) {
       console.error('Failed to create order', err);
     } finally {
@@ -89,7 +92,7 @@ const CartScreen = ({ navigation, route }: any) => {
               <Text style={[styles.emptyText, { color: theme.colors.onSurface }]}>{t('cart.empty')}</Text>
               <Button
                 mode="contained"
-                onPress={() => navigation.navigate(t('navigation.catalog'))}
+                onPress={() => navigation.navigate(RouteName.CATALOG as never)}
                 style={styles.shopButton}
                 buttonColor={theme.colors.primary}
                 textColor={theme.colors.onPrimary}
@@ -189,7 +192,7 @@ const CartScreen = ({ navigation, route }: any) => {
                 {t('payment.title')}:
               </Text>
               <DirectLinkButton
-                screenName="PaymentScreen"
+                screenName={RouteName.PAYMENT_SCREEN}
                 params={{ amount: calculateTotal().toString() }}
                 style={styles.directLinkButton}
               >

--- a/frontend/src/screens/CatalogScreen.tsx
+++ b/frontend/src/screens/CatalogScreen.tsx
@@ -4,6 +4,7 @@ import { Card, Searchbar, Chip, Text, Button, useTheme, ActivityIndicator } from
 import { Product, Category } from '../types';
 import { useTranslation } from 'react-i18next';
 import { getCatalog, getCategories } from '../api/api';
+import RouteName from '../navigation/routes';
 
 const CatalogScreen = ({ navigation }: any) => {
   const { t } = useTranslation();
@@ -40,7 +41,11 @@ const CatalogScreen = ({ navigation }: any) => {
   const renderProduct = ({ item }: { item: Product }) => (
     <Card
       style={[styles.card, { backgroundColor: theme.colors.surface }]}
-      onPress={() => navigation.navigate('ProductDetails', { product: item })}
+      onPress={() =>
+        navigation.navigate(RouteName.PRODUCT_DETAILS as never, {
+          product: item,
+        } as never)
+      }
     >
       <View style={styles.imageContainer}>
         <Card.Cover
@@ -76,7 +81,11 @@ const CatalogScreen = ({ navigation }: any) => {
       <Card.Actions style={styles.cardActions}>
         <Button 
           mode="contained" 
-          onPress={() => navigation.navigate('ProductDetails', { product: item })}
+          onPress={() =>
+            navigation.navigate(RouteName.PRODUCT_DETAILS as never, {
+              product: item,
+            } as never)
+          }
           buttonColor={theme.colors.primary}
           textColor={theme.colors.onPrimary}
           style={styles.viewButton}

--- a/frontend/src/screens/OrderHistoryScreen.tsx
+++ b/frontend/src/screens/OrderHistoryScreen.tsx
@@ -4,6 +4,7 @@ import { Card, Text, Chip, Divider, Button, ActivityIndicator, useTheme } from '
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
 import { listOrders } from '../api/api';
+import RouteName from '../navigation/routes';
 
 const OrderHistoryScreen = ({ navigation, route }: any) => {
   const theme = useTheme();
@@ -99,7 +100,11 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
   const renderOrderItem = ({ item }: { item: Order }) => (
     <Card 
       style={[styles.orderCard, { backgroundColor: theme.colors.surface }]}
-      onPress={() => navigation.navigate('OrderStatus', { orderId: item.id })}
+      onPress={() =>
+        navigation.navigate(RouteName.ORDER_STATUS as never, {
+          orderId: item.id,
+        } as never)
+      }
     >
       <Card.Content>
         <View style={styles.orderHeader}>
@@ -214,7 +219,7 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
           </Text>
           <Button
             mode="contained"
-            onPress={() => navigation.navigate(t('navigation.catalog'))}
+            onPress={() => navigation.navigate(RouteName.CATALOG as never)}
             style={styles.catalogButton}
             buttonColor={theme.colors.primary}
             textColor={theme.colors.onPrimary}

--- a/frontend/src/screens/OrderStatusScreen.tsx
+++ b/frontend/src/screens/OrderStatusScreen.tsx
@@ -4,6 +4,7 @@ import { Card, Text, ActivityIndicator, Button, useTheme } from 'react-native-pa
 import { Order, OrderStatus } from '../types';
 import { useTranslation } from 'react-i18next';
 import { getOrder } from '../api/api';
+import RouteName from '../navigation/routes';
 
 const OrderStatusScreen = ({ route, navigation }: any) => {
   const theme = useTheme();
@@ -107,7 +108,7 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
         <Text style={{ color: theme.colors.onBackground }}>{t('orderStatus.orderNotFound')}</Text>
         <Button
           mode="contained"
-          onPress={() => navigation.navigate(t('navigation.catalog'))}
+          onPress={() => navigation.navigate(RouteName.CATALOG as never)}
           style={styles.button}
           buttonColor={theme.colors.primary}
           textColor={theme.colors.onPrimary}
@@ -175,7 +176,7 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
       <View style={styles.buttonContainer}>
         <Button
           mode="contained"
-          onPress={() => navigation.navigate(t('navigation.catalog'))}
+          onPress={() => navigation.navigate(RouteName.CATALOG as never)}
           style={[styles.button, { flex: 1, marginRight: 8 }]}
           buttonColor={theme.colors.primary}
           textColor={theme.colors.onPrimary}
@@ -185,7 +186,7 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
         
         <Button
           mode="outlined"
-          onPress={() => navigation.navigate('OrderHistoryScreen')}
+          onPress={() => navigation.navigate(RouteName.ORDER_HISTORY_SCREEN as never)}
           style={[styles.button, { flex: 1, marginLeft: 8 }]}
           textColor={theme.colors.primary}
         >

--- a/frontend/src/screens/PaymentScreen.tsx
+++ b/frontend/src/screens/PaymentScreen.tsx
@@ -4,6 +4,7 @@ import { Text, useTheme } from 'react-native-paper';
 import PaymentForm from '../components/PaymentForm';
 import { useTranslation } from 'react-i18next';
 import { useNavigation } from '@react-navigation/native';
+import RouteName from '../navigation/routes';
 
 // Интерфейс для параметров маршрута
 interface PaymentScreenProps {
@@ -28,8 +29,8 @@ const PaymentScreen: React.FC<PaymentScreenProps> = ({ route }) => {
   
   const handlePaymentComplete = (paymentMethod: any) => {
     // Переходим на экран статуса заказа после успешной оплаты
-    navigation.navigate('OrderStatus' as never, { 
-      orderId: `order-${Date.now()}` 
+    navigation.navigate(RouteName.ORDER_STATUS as never, {
+      orderId: `order-${Date.now()}`
     } as never);
   };
   

--- a/frontend/src/screens/ProductDetailsScreen.tsx
+++ b/frontend/src/screens/ProductDetailsScreen.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet, ScrollView, Image, TouchableOpacity } from 'react-nat
 import { Button, Text, Card, Snackbar, Divider, List, useTheme } from 'react-native-paper';
 import { MaterialCommunityIcon } from '../components/CustomIcons';
 import { Product, OrderItem } from '../types';
+import RouteName from '../navigation/routes';
 import { useTranslation } from 'react-i18next';
 
 const ProductDetailsScreen = ({ route, navigation }: any) => {
@@ -34,7 +35,7 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
 
     // Navigate back to catalog after a short delay
     setTimeout(() => {
-      navigation.navigate(t('navigation.cart'), { newItem: item });
+      navigation.navigate(RouteName.CART as never, { newItem: item } as never);
     }, 1500);
   };
 
@@ -186,7 +187,7 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
         duration={1500}
         action={{
           label: t('navigation.cart'),
-          onPress: () => navigation.navigate(t('navigation.cart')),
+          onPress: () => navigation.navigate(RouteName.CART as never),
         }}
         style={{ backgroundColor: theme.colors.surfaceVariant }}
         theme={{

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -4,6 +4,7 @@ import { Card, Text, Switch, Button, List, Divider, useTheme } from 'react-nativ
 import { useTranslation } from 'react-i18next';
 import DirectLinkButton from '../components/DirectLinkButton';
 import { listOrders } from '../api/api';
+import RouteName from '../navigation/routes';
 
 const ProfileScreen = ({ navigation, route }: any) => {
   const seatNumber = route.params?.seatNumber as string;
@@ -105,7 +106,11 @@ const ProfileScreen = ({ navigation, route }: any) => {
                 {ordersCount}
               </Text>
             </View>}
-            onPress={() => navigation.navigate('OrderHistoryScreen', { seatNumber })}
+            onPress={() =>
+              navigation.navigate(RouteName.ORDER_HISTORY_SCREEN as never, {
+                seatNumber,
+              } as never)
+            }
           />
           
           <Divider style={{ backgroundColor: theme.colors.outline }} />
@@ -116,7 +121,7 @@ const ProfileScreen = ({ navigation, route }: any) => {
             titleStyle={{ color: theme.colors.onSurface }}
             descriptionStyle={{ color: theme.colors.onSurfaceVariant }}
             left={props => <List.Icon {...props} icon="credit-card" color={theme.colors.primary} />}
-            onPress={() => navigation.navigate('PaymentScreen')}
+            onPress={() => navigation.navigate(RouteName.PAYMENT_SCREEN as never)}
           />
           
           <Divider style={{ backgroundColor: theme.colors.outline }} />
@@ -140,21 +145,21 @@ const ProfileScreen = ({ navigation, route }: any) => {
           
           <View style={styles.linksContainer}>
             <DirectLinkButton
-              screenName="CatalogScreen"
+              screenName={RouteName.CATALOG_SCREEN}
               style={styles.linkButton}
             >
               {t('navigation.catalog')}
             </DirectLinkButton>
             
             <DirectLinkButton
-              screenName="CartScreen"
+              screenName={RouteName.CART_SCREEN}
               style={styles.linkButton}
             >
               {t('navigation.cart')}
             </DirectLinkButton>
             
             <DirectLinkButton
-              screenName="OrderHistoryScreen"
+              screenName={RouteName.ORDER_HISTORY_SCREEN}
               style={styles.linkButton}
               params={{ seatNumber }}
             >
@@ -162,7 +167,7 @@ const ProfileScreen = ({ navigation, route }: any) => {
             </DirectLinkButton>
             
             <DirectLinkButton
-              screenName="PaymentScreen"
+              screenName={RouteName.PAYMENT_SCREEN}
               style={styles.linkButton}
             >
               {t('payment.title')}


### PR DESCRIPTION
## Summary
- centralize navigation route names in `RouteName` enum
- use the new constants in navigators and screens

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684910c1fca88331bee014d907c11176