### PR TITLE
Add Support screen and translations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import AdminPanel from './screens/AdminPanel';
 import ProductDetailsScreen from './screens/ProductDetailsScreen';
 import PaymentScreen from './screens/PaymentScreen';
 import OrderHistoryScreen from './screens/OrderHistoryScreen';
+import SupportScreen from './screens/SupportScreen';
 
 // Определение типов для навигации
 declare global {
@@ -42,6 +43,7 @@ declare global {
       OrderStatusScreen: { id: string };
       PaymentScreen: { amount?: number };
       OrderHistoryScreen: undefined;
+      SupportScreen: undefined;
     }
   }
 }
@@ -100,6 +102,7 @@ const linking = {
       OrderStatusScreen: 'OrderStatusScreen/:id',
       PaymentScreen: 'PaymentScreen/:amount?',
       OrderHistoryScreen: 'OrderHistoryScreen',
+      SupportScreen: 'SupportScreen',
     }
   },
   // Обработка URL, которые не соответствуют конфигурации
@@ -114,7 +117,8 @@ const linking = {
       RouteName.PRODUCT_DETAILS_SCREEN,
       RouteName.ORDER_STATUS_SCREEN,
       RouteName.PAYMENT_SCREEN,
-      RouteName.ORDER_HISTORY_SCREEN
+      RouteName.ORDER_HISTORY_SCREEN,
+      RouteName.SUPPORT_SCREEN
     ];
     
     // Проверка на соответствие имени компонента
@@ -365,6 +369,11 @@ const RootStackNavigator = () => {
         component={OrderHistoryScreen}
         options={{ title: t('navigation.orderHistory') }}
         initialParams={{ seatNumber }}
+      />
+      <Stack.Screen
+        name={RouteName.SUPPORT_SCREEN}
+        component={SupportScreen}
+        options={{ title: t('support.title') }}
       />
     </Stack.Navigator>
   );

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -195,9 +195,15 @@ export default {
     preferences: 'Preferences',
     language: 'Language',
     darkMode: 'Dark mode',
+    darkModeDescription: 'Toggle between dark and light themes',
     notifications: 'Notifications',
+    notificationsDescription: 'Receive updates about your orders',
     orderHistory: 'Order history',
+    orderHistoryDescription: 'View your past orders',
     savedPaymentMethods: 'Saved payment methods',
+    paymentMethodsDescription: 'Manage your payment methods',
+    helpSupport: 'Help & support',
+    helpSupportDescription: 'Get help with your orders',
     logout: 'Logout',
     editProfile: 'Edit profile',
     changePassword: 'Change password',
@@ -259,4 +265,9 @@ export default {
     promotions: 'Promotions',
     system: 'System',
   },
-}; 
+
+  // Support screen
+  support: {
+    title: 'Support',
+  },
+};

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -272,4 +272,9 @@ export default {
     promotions: 'Акции',
     system: 'Системные',
   },
-}; 
+
+  // Экран поддержки
+  support: {
+    title: 'Поддержка',
+  },
+};

--- a/frontend/src/navigation/routes.ts
+++ b/frontend/src/navigation/routes.ts
@@ -16,7 +16,8 @@ export enum RouteName {
   ORDER_STATUS_SCREEN = 'OrderStatusScreen',
   PAYMENT_SCREEN = 'PaymentScreen',
   ORDER_HISTORY_SCREEN = 'OrderHistoryScreen',
-  ORDER_DETAILS = 'OrderDetails'
+  ORDER_DETAILS = 'OrderDetails',
+  SUPPORT_SCREEN = 'SupportScreen'
 }
 
 export default RouteName;

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -132,7 +132,7 @@ const ProfileScreen = ({ navigation, route }: any) => {
             titleStyle={{ color: theme.colors.onSurface }}
             descriptionStyle={{ color: theme.colors.onSurfaceVariant }}
             left={props => <List.Icon {...props} icon="help-circle" color={theme.colors.primary} />}
-            onPress={() => navigation.navigate('Support')}
+            onPress={() => navigation.navigate(RouteName.SUPPORT_SCREEN as never)}
           />
         </Card.Content>
       </Card>

--- a/frontend/src/screens/SupportScreen.tsx
+++ b/frontend/src/screens/SupportScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text, useTheme } from 'react-native-paper';
+import { useTranslation } from 'react-i18next';
+
+const SupportScreen = () => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <Text style={{ color: theme.colors.onBackground }}>{t('support.title')}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default SupportScreen;


### PR DESCRIPTION
## Summary
- create a minimal `SupportScreen`
- register new `SUPPORT_SCREEN` route
- link Profile help item to the new screen
- add English translations and minimal Russian support strings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684912c84d8c83319cc77987736f4e7e