### PR TITLE
Add order details screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import ProductDetailsScreen from './screens/ProductDetailsScreen';
 import PaymentScreen from './screens/PaymentScreen';
 import OrderHistoryScreen from './screens/OrderHistoryScreen';
 import SupportScreen from './screens/SupportScreen';
+import OrderDetailsScreen from './screens/OrderDetailsScreen';
 
 // Определение типов для навигации
 declare global {
@@ -34,6 +35,7 @@ declare global {
       AdminRoot: undefined;
       ProductDetails: { id: string };
       OrderStatus: { orderId: string };
+      OrderDetails: { orderId: string };
       CatalogScreen: undefined;
       CartScreen: undefined;
       ProfileScreen: undefined;
@@ -41,6 +43,7 @@ declare global {
       AdminPanel: undefined;
       ProductDetailsScreen: { id: string };
       OrderStatusScreen: { id: string };
+      OrderDetailsScreen: { id: string };
       PaymentScreen: { amount?: number };
       OrderHistoryScreen: undefined;
       SupportScreen: undefined;
@@ -92,6 +95,7 @@ const linking = {
       },
       ProductDetails: 'product/:id',
       OrderStatus: 'order/:id',
+      OrderDetails: 'order-details/:id',
       // Добавляем прямые ссылки на экраны для доступа по имени компонента
       CatalogScreen: 'CatalogScreen',
       CartScreen: 'CartScreen',
@@ -100,6 +104,7 @@ const linking = {
       AdminPanel: 'AdminPanel',
       ProductDetailsScreen: 'ProductDetailsScreen/:id',
       OrderStatusScreen: 'OrderStatusScreen/:id',
+      OrderDetailsScreen: 'OrderDetailsScreen/:id',
       PaymentScreen: 'PaymentScreen/:amount?',
       OrderHistoryScreen: 'OrderHistoryScreen',
       SupportScreen: 'SupportScreen',
@@ -116,6 +121,7 @@ const linking = {
       RouteName.ADMIN_PANEL,
       RouteName.PRODUCT_DETAILS_SCREEN,
       RouteName.ORDER_STATUS_SCREEN,
+      RouteName.ORDER_DETAILS_SCREEN,
       RouteName.PAYMENT_SCREEN,
       RouteName.ORDER_HISTORY_SCREEN,
       RouteName.SUPPORT_SCREEN
@@ -130,7 +136,7 @@ const linking = {
       const segments = path.split('/');
       
       if (segments.length > 1) {
-        if (['ProductDetailsScreen', 'OrderStatusScreen'].includes(componentMatch)) {
+        if (['ProductDetailsScreen', 'OrderStatusScreen', 'OrderDetailsScreen'].includes(componentMatch)) {
           params.id = segments[1];
         } else if (componentMatch === 'PaymentScreen') {
           params.amount = segments[1];
@@ -321,6 +327,11 @@ const RootStackNavigator = () => {
         component={OrderStatusScreen}
         options={{ title: t('orderStatus.title') }}
       />
+      <Stack.Screen
+        name={RouteName.ORDER_DETAILS}
+        component={OrderDetailsScreen}
+        options={{ title: t('orderDetails.title') }}
+      />
       
       {/* Прямой доступ к компонентам по их именам */}
       <Stack.Screen
@@ -358,6 +369,11 @@ const RootStackNavigator = () => {
         name={RouteName.ORDER_STATUS_SCREEN}
         component={OrderStatusScreen}
         options={{ title: t('orderStatus.title') }}
+      />
+      <Stack.Screen
+        name={RouteName.ORDER_DETAILS_SCREEN}
+        component={OrderDetailsScreen}
+        options={{ title: t('orderDetails.title') }}
       />
       <Stack.Screen
         name={RouteName.PAYMENT_SCREEN}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -184,6 +184,11 @@ export default {
     confirmCancel: 'Are you sure you want to cancel your order?',
   },
 
+  // Order details screen
+  orderDetails: {
+    title: 'Order Details',
+  },
+
   // Profile screen
   profile: {
     title: 'Profile',

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -191,6 +191,11 @@ export default {
     noOrders: 'У вас пока нет заказов',
   },
 
+  // Экран деталей заказа
+  orderDetails: {
+    title: 'Детали заказа',
+  },
+
   // Экран профиля
   profile: {
     title: 'Профиль',

--- a/frontend/src/navigation/routes.ts
+++ b/frontend/src/navigation/routes.ts
@@ -17,6 +17,7 @@ export enum RouteName {
   PAYMENT_SCREEN = 'PaymentScreen',
   ORDER_HISTORY_SCREEN = 'OrderHistoryScreen',
   ORDER_DETAILS = 'OrderDetails',
+  ORDER_DETAILS_SCREEN = 'OrderDetailsScreen',
   SUPPORT_SCREEN = 'SupportScreen'
 }
 

--- a/frontend/src/screens/OrderDetailsScreen.tsx
+++ b/frontend/src/screens/OrderDetailsScreen.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Card, Text, ActivityIndicator, List } from 'react-native-paper';
+import { useTranslation } from 'react-i18next';
+import { getOrder } from '../api/api';
+import { Order, OrderItem, OrderStatus } from '../types';
+
+const OrderDetailsScreen = ({ route }: any) => {
+  const { t } = useTranslation();
+  const [order, setOrder] = useState<Order | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadOrder = async () => {
+      try {
+        setLoading(true);
+        const data = await getOrder(route.params.orderId);
+        setOrder(data);
+      } catch (err: any) {
+        console.error('Error loading order:', err);
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadOrder();
+  }, [route.params.orderId]);
+
+  const getStatusLabel = (status: OrderStatus) => {
+    switch (status) {
+      case OrderStatus.PENDING:
+        return t('orderStatus.pending');
+      case OrderStatus.PREPARING:
+        return t('orderStatus.preparing');
+      case OrderStatus.DELIVERING:
+        return t('orderStatus.delivering');
+      case OrderStatus.COMPLETED:
+        return t('orderStatus.completed');
+      case OrderStatus.CANCELLED:
+        return t('orderStatus.cancelled');
+      default:
+        return status;
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator animating />
+      </View>
+    );
+  }
+
+  if (!order) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text>{t('orderStatus.orderNotFound')}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Card style={styles.card}>
+        <Card.Title title={`${t('orderStatus.orderNumber')}: ${order.id}`} />
+        <Card.Content>
+          <Text>{t('orderStatus.orderStatus')}: {getStatusLabel(order.status)}</Text>
+          <Text>{t('orderStatus.orderTotal')}: ${order.totalAmount.toFixed(2)}</Text>
+          <Text>{t('profile.seatNumber')}: {order.seatNumber}</Text>
+        </Card.Content>
+      </Card>
+      <Card style={styles.card}>
+        <Card.Title title={t('orderStatus.orderItems')} />
+        <Card.Content>
+          {order.items.map((item: OrderItem) => (
+            <List.Item
+              key={item.productId}
+              title={`${item.name} x${item.quantity}`}
+              description={`$${(item.price * item.quantity).toFixed(2)}`}
+            />
+          ))}
+        </Card.Content>
+      </Card>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 10,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  card: {
+    marginBottom: 10,
+  },
+});
+
+export default OrderDetailsScreen;


### PR DESCRIPTION
## Summary
- implement `OrderDetailsScreen` for viewing single order
- register new route constants
- update navigation and linking
- add translations for OrderDetails title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684913d5275883319db31a40ee7ffbc3