### PR TITLE
Refactor deep links to use route constants

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import './i18n/i18n'; // Import i18n settings
 import { initLanguage } from './i18n/i18n';
 import MobileContainer from './components/MobileContainer';
 import DeepLinkHandler from './components/DeepLinkHandler';
-import RouteName from './navigation/routes';
+import RouteName, { RoutePath } from './navigation/routes';
 
 // Import screens
 import LoginScreen from './screens/LoginScreen';
@@ -80,34 +80,34 @@ const linking = {
   config: {
     // Конфигурация навигации
     screens: {
-      Login: 'login',
-      MainApp: {
+      [RouteName.LOGIN]: RoutePath[RouteName.LOGIN],
+      [RouteName.MAIN_APP]: {
         screens: {
-          [RouteName.CATALOG]: 'catalog',
-          [RouteName.CART]: 'cart',
-          [RouteName.PROFILE]: 'profile',
+          [RouteName.CATALOG]: RoutePath[RouteName.CATALOG],
+          [RouteName.CART]: RoutePath[RouteName.CART],
+          [RouteName.PROFILE]: RoutePath[RouteName.PROFILE],
         }
       },
-      AdminRoot: {
+      [RouteName.ADMIN_ROOT]: {
         screens: {
-          [RouteName.ADMIN_PANEL]: 'admin'
+          [RouteName.ADMIN_PANEL]: RoutePath[RouteName.ADMIN_PANEL]
         }
       },
-      ProductDetails: 'product/:id',
-      OrderStatus: 'order/:id',
-      OrderDetails: 'order-details/:id',
+      [RouteName.PRODUCT_DETAILS]: RoutePath[RouteName.PRODUCT_DETAILS],
+      [RouteName.ORDER_STATUS]: RoutePath[RouteName.ORDER_STATUS],
+      [RouteName.ORDER_DETAILS]: RoutePath[RouteName.ORDER_DETAILS],
       // Добавляем прямые ссылки на экраны для доступа по имени компонента
-      CatalogScreen: 'CatalogScreen',
-      CartScreen: 'CartScreen',
-      ProfileScreen: 'ProfileScreen',
-      LoginScreen: 'LoginScreen',
-      AdminPanel: 'AdminPanel',
-      ProductDetailsScreen: 'ProductDetailsScreen/:id',
-      OrderStatusScreen: 'OrderStatusScreen/:id',
-      OrderDetailsScreen: 'OrderDetailsScreen/:id',
-      PaymentScreen: 'PaymentScreen/:amount?',
-      OrderHistoryScreen: 'OrderHistoryScreen',
-      SupportScreen: 'SupportScreen',
+      [RouteName.CATALOG_SCREEN]: RoutePath[RouteName.CATALOG_SCREEN],
+      [RouteName.CART_SCREEN]: RoutePath[RouteName.CART_SCREEN],
+      [RouteName.PROFILE_SCREEN]: RoutePath[RouteName.PROFILE_SCREEN],
+      [RouteName.LOGIN_SCREEN]: RoutePath[RouteName.LOGIN_SCREEN],
+      [RouteName.ADMIN_PANEL]: RoutePath[RouteName.ADMIN_PANEL],
+      [RouteName.PRODUCT_DETAILS_SCREEN]: RoutePath[RouteName.PRODUCT_DETAILS_SCREEN],
+      [RouteName.ORDER_STATUS_SCREEN]: RoutePath[RouteName.ORDER_STATUS_SCREEN],
+      [RouteName.ORDER_DETAILS_SCREEN]: RoutePath[RouteName.ORDER_DETAILS_SCREEN],
+      [RouteName.PAYMENT_SCREEN]: RoutePath[RouteName.PAYMENT_SCREEN],
+      [RouteName.ORDER_HISTORY_SCREEN]: RoutePath[RouteName.ORDER_HISTORY_SCREEN],
+      [RouteName.SUPPORT_SCREEN]: RoutePath[RouteName.SUPPORT_SCREEN],
     }
   },
   // Обработка URL, которые не соответствуют конфигурации
@@ -136,9 +136,9 @@ const linking = {
       const segments = path.split('/');
       
       if (segments.length > 1) {
-        if (['ProductDetailsScreen', 'OrderStatusScreen', 'OrderDetailsScreen'].includes(componentMatch)) {
+        if ([RouteName.PRODUCT_DETAILS_SCREEN, RouteName.ORDER_STATUS_SCREEN, RouteName.ORDER_DETAILS_SCREEN].includes(componentMatch as RouteName)) {
           params.id = segments[1];
-        } else if (componentMatch === 'PaymentScreen') {
+        } else if (componentMatch === RouteName.PAYMENT_SCREEN) {
           params.amount = segments[1];
         }
       }

--- a/frontend/src/components/DeepLinkHandler.tsx
+++ b/frontend/src/components/DeepLinkHandler.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Linking } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import RouteName, { RoutePath } from '../navigation/routes';
 
 /**
  * DeepLinkHandler - компонент для обработки deeplink и навигации по URL
@@ -17,27 +18,40 @@ const DeepLinkHandler = () => {
   const handleDeepLink = (event: { url: string }) => {
     const { url } = event;
     console.log('Received deep link:', url);
-    
-    // Получаем путь из URL (часть после доменного имени)
-    const path = url.split('//')[1].split('/').slice(1);
-    if (path.length === 0) return;
-    
-    const componentName = path[0];
-    const componentParam = path[1];
-    
-    console.log('Component name:', componentName);
-    console.log('Component param:', componentParam);
-    
-    // Список компонентов, которые могут принимать параметры
-    const componentsWithParams = ['ProductDetailsScreen', 'OrderStatusScreen', 'ProductDetails', 'OrderStatus'];
-    
-    // Выполняем навигацию в соответствии с полученным URL
-    if (componentsWithParams.includes(componentName) && componentParam) {
-      // Для экранов с параметрами
-      navigation.navigate(componentName as never, { id: componentParam } as never);
+
+    const segments = url.split('//')[1].split('/').slice(1);
+    if (segments.length === 0) return;
+
+    const pathSegment = segments[0];
+    const param = segments[1];
+
+    // Находим имя маршрута по базовому пути
+    const routeEntry = Object.entries(RoutePath).find(([, value]) => value.split('/')[0] === pathSegment);
+    if (!routeEntry) return;
+
+    const routeName = routeEntry[0] as RouteName;
+
+    // Список экранов, принимающих параметры
+    const componentsWithParams = [
+      RouteName.PRODUCT_DETAILS_SCREEN,
+      RouteName.ORDER_STATUS_SCREEN,
+      RouteName.PRODUCT_DETAILS,
+      RouteName.ORDER_STATUS,
+      RouteName.ORDER_DETAILS,
+      RouteName.ORDER_DETAILS_SCREEN,
+      RouteName.PAYMENT_SCREEN
+    ];
+
+    if (componentsWithParams.includes(routeName) && param) {
+      const params: Record<string, string> = {};
+      if (routeName === RouteName.PAYMENT_SCREEN) {
+        params.amount = param;
+      } else {
+        params.id = param;
+      }
+      navigation.navigate(routeName as never, params as never);
     } else {
-      // Для экранов без параметров
-      navigation.navigate(componentName as never);
+      navigation.navigate(routeName as never);
     }
   };
 
@@ -61,4 +75,4 @@ const DeepLinkHandler = () => {
   return null;
 };
 
-export default DeepLinkHandler; 
+export default DeepLinkHandler;

--- a/frontend/src/navigation/routes.ts
+++ b/frontend/src/navigation/routes.ts
@@ -21,4 +21,28 @@ export enum RouteName {
   SUPPORT_SCREEN = 'SupportScreen'
 }
 
+// Stable paths for deep links
+export const RoutePath: Record<RouteName, string> = {
+  [RouteName.LOGIN]: 'login',
+  [RouteName.MAIN_APP]: '',
+  [RouteName.ADMIN_ROOT]: '',
+  [RouteName.CATALOG]: 'catalog',
+  [RouteName.CART]: 'cart',
+  [RouteName.PROFILE]: 'profile',
+  [RouteName.ADMIN_PANEL]: 'admin',
+  [RouteName.PRODUCT_DETAILS]: 'product/:id',
+  [RouteName.ORDER_STATUS]: 'order/:id',
+  [RouteName.CATALOG_SCREEN]: 'CatalogScreen',
+  [RouteName.CART_SCREEN]: 'CartScreen',
+  [RouteName.PROFILE_SCREEN]: 'ProfileScreen',
+  [RouteName.LOGIN_SCREEN]: 'LoginScreen',
+  [RouteName.PRODUCT_DETAILS_SCREEN]: 'ProductDetailsScreen/:id',
+  [RouteName.ORDER_STATUS_SCREEN]: 'OrderStatusScreen/:id',
+  [RouteName.PAYMENT_SCREEN]: 'PaymentScreen/:amount?',
+  [RouteName.ORDER_HISTORY_SCREEN]: 'OrderHistoryScreen',
+  [RouteName.ORDER_DETAILS]: 'order-details/:id',
+  [RouteName.ORDER_DETAILS_SCREEN]: 'OrderDetailsScreen/:id',
+  [RouteName.SUPPORT_SCREEN]: 'SupportScreen'
+};
+
 export default RouteName;


### PR DESCRIPTION
## Summary
- centralize stable paths in `RoutePath`
- reference `RoutePath` in linking configuration
- use route constants when parsing incoming deep links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491528409483319d7c9dbe9f4514fa