### PR TITLE
Fix duplicate AdminPanel route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,6 @@ const linking = {
       [RouteName.CART_SCREEN]: RoutePath[RouteName.CART_SCREEN],
       [RouteName.PROFILE_SCREEN]: RoutePath[RouteName.PROFILE_SCREEN],
       [RouteName.LOGIN_SCREEN]: RoutePath[RouteName.LOGIN_SCREEN],
-      [RouteName.ADMIN_PANEL]: RoutePath[RouteName.ADMIN_PANEL],
       [RouteName.PRODUCT_DETAILS_SCREEN]: RoutePath[RouteName.PRODUCT_DETAILS_SCREEN],
       [RouteName.ORDER_STATUS_SCREEN]: RoutePath[RouteName.ORDER_STATUS_SCREEN],
       [RouteName.ORDER_DETAILS_SCREEN]: RoutePath[RouteName.ORDER_DETAILS_SCREEN],
@@ -354,11 +353,6 @@ const RootStackNavigator = () => {
         name={RouteName.LOGIN_SCREEN}
         component={LoginScreen}
         options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name={RouteName.ADMIN_PANEL}
-        component={AdminPanel}
-        options={{ title: t('navigation.admin') }}
       />
       <Stack.Screen
         name={RouteName.PRODUCT_DETAILS_SCREEN}


### PR DESCRIPTION
## Summary
- remove duplicate AdminPanel screen from linking config
- drop ADMIN_PANEL screen from RootStackNavigator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684917139ecc83318747ec6f1853e26e