### PR TITLE
Update language selection

### DIFF
--- a/airservice/api/admin.py
+++ b/airservice/api/admin.py
@@ -83,7 +83,7 @@ def list_orders():
         except ValueError:
             pass
     orders = qs.all()
-    lang = request.args.get('lang')
+    lang = request.args.get('lang') or request.accept_languages.best_match(['ru', 'en']) or 'ru'
     return jsonify([
         {
             'id': o.id,

--- a/airservice/api/catalog.py
+++ b/airservice/api/catalog.py
@@ -106,7 +106,7 @@ def catalog():
             Item.description_en.ilike(like)
         )
     items = qs.all()
-    lang = request.args.get('lang')
+    lang = request.args.get('lang') or request.accept_languages.best_match(['ru', 'en']) or 'ru'
     data = []
     for i in items:
         lang_item = 'en' if lang == 'en' else 'ru'
@@ -162,7 +162,7 @@ def catalog_categories():
                           type: array
                           items: {}
     """
-    lang = request.args.get('lang')
+    lang = request.args.get('lang') or request.accept_languages.best_match(['ru', 'en']) or 'ru'
     cats = Category.query.order_by(Category.id).all()
     nodes = {
         c.id: {

--- a/airservice/api/orders.py
+++ b/airservice/api/orders.py
@@ -122,7 +122,7 @@ def get_order(order_id):
     order = order_service.get_order(order_id)
     if not order:
         abort(404)
-    lang = request.args.get('lang')
+    lang = request.args.get('lang') or request.accept_languages.best_match(['ru', 'en']) or 'ru'
     items = [
         {
             'item_id': oi.item.id,
@@ -154,7 +154,7 @@ def list_orders():
     if status_f:
         qs = qs.filter(Order.status == status_f)
     orders = qs.order_by(Order.created_at).all()
-    lang = request.args.get('lang')
+    lang = request.args.get('lang') or request.accept_languages.best_match(['ru', 'en']) or 'ru'
     response = []
     for o in orders:
         items = [

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -124,7 +124,7 @@ def test_catalog_price_and_service_filters(client, sample_data):
 
 
 def test_catalog_categories_hierarchy(client, sample_data):
-    rv = client.get('/catalog/categories')
+    rv = client.get('/catalog/categories', headers={'Accept-Language': 'en'})
     assert rv.status_code == 200
     data = rv.get_json()
     # root categories


### PR DESCRIPTION
## Summary
- extend language detection logic to check `Accept-Language` header when no `lang` query parameter is provided
- update admin and order APIs to use the same rule
- adjust catalogue category tests to specify English via headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0c124abc83318addd853179442d0