### PR TITLE
Reload data when language changes

### DIFF
--- a/frontend/src/screens/CatalogScreen.tsx
+++ b/frontend/src/screens/CatalogScreen.tsx
@@ -8,7 +8,7 @@ import { formatPrice } from '../utils/currency';
 import RouteName from '../navigation/routes';
 
 const CatalogScreen = ({ navigation }: any) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const theme = useTheme();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -31,7 +31,7 @@ const CatalogScreen = ({ navigation }: any) => {
       }
     };
     loadData();
-  }, []);
+  }, [i18n.language]);
 
   const filteredProducts = products.filter((product) => {
     const matchesSearch = product.name.toLowerCase().includes(searchQuery.toLowerCase());

--- a/frontend/src/screens/OrderDetailsScreen.tsx
+++ b/frontend/src/screens/OrderDetailsScreen.tsx
@@ -7,7 +7,7 @@ import { Order, OrderItem, OrderStatus } from '../types';
 import { formatPrice } from '../utils/currency';
 
 const OrderDetailsScreen = ({ route }: any) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -27,7 +27,7 @@ const OrderDetailsScreen = ({ route }: any) => {
     };
 
     loadOrder();
-  }, [route.params.orderId]);
+  }, [route.params.orderId, i18n.language]);
 
   const getStatusLabel = (status: OrderStatus) => {
     switch (status) {

--- a/frontend/src/screens/OrderHistoryScreen.tsx
+++ b/frontend/src/screens/OrderHistoryScreen.tsx
@@ -9,7 +9,7 @@ import { formatPrice } from '../utils/currency';
 
 const OrderHistoryScreen = ({ navigation, route }: any) => {
   const theme = useTheme();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const seatNumber = route.params?.seatNumber as string;
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
@@ -32,7 +32,7 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
     };
 
     loadOrders();
-  }, []);
+  }, [i18n.language]);
 
   // Фильтрация заказов по статусу
   const filteredOrders = selectedFilter

--- a/frontend/src/screens/OrderStatusScreen.tsx
+++ b/frontend/src/screens/OrderStatusScreen.tsx
@@ -9,7 +9,7 @@ import { formatPrice } from '../utils/currency';
 
 const OrderStatusScreen = ({ route, navigation }: any) => {
   const theme = useTheme();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -30,7 +30,7 @@ const OrderStatusScreen = ({ route, navigation }: any) => {
     };
 
     loadOrder();
-  }, [route.params.orderId]);
+  }, [route.params.orderId, i18n.language]);
 
   const getStatusColor = (status: OrderStatus) => {
     switch (status) {


### PR DESCRIPTION
## Summary
- trigger catalog and order screens to reload data on language switch
- include `i18n` in translation hooks

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f0d2eaaac833189a7ca49f3615865