### PR TITLE
Add default language test for catalog

### DIFF
--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -35,3 +35,10 @@ def test_invalid_item_ids_en(client, sample_data):
     assert 'Invalid item IDs' in rv.get_json()['error']
 
 
+def test_catalog_default_language(client, sample_data):
+    rv = client.get('/catalog')
+    assert rv.status_code == 200
+    names = {i['name'] for i in rv.get_json()}
+    assert 'Борщ' in names
+
+


### PR DESCRIPTION
## Summary
- add regression test covering default Russian language

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0e4d3b98833182f8c8ee20a70fad