### PR TITLE
Remove direct links section and add missing translations

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -31,6 +31,7 @@ export default {
     quantity: 'Quantity',
     total: 'Total',
     currency: '$',
+    all: 'All',
   },
 
   // Navigation
@@ -38,6 +39,7 @@ export default {
     catalog: 'Catalog',
     cart: 'Cart',
     profile: 'Profile',
+    orderHistory: 'Order history',
     orders: 'Orders',
     settings: 'Settings',
     admin: 'Admin Panel',
@@ -182,6 +184,11 @@ export default {
     orderDelivered: 'Order delivered',
     orderCancelled: 'Order cancelled',
     confirmCancel: 'Are you sure you want to cancel your order?',
+    orderNotFound: 'Order not found',
+    moreItems: 'and {{count}} more items',
+    filterByStatus: 'Filter by status',
+    orderHistory: 'Order history',
+    noOrders: 'You have no orders yet',
   },
 
   // Order details screen

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -4,7 +4,6 @@ import { Card, Text, Switch, Button, List, Divider, useTheme } from 'react-nativ
 import { useThemeContext } from '../theme/ThemeProvider';
 import { useTranslation } from 'react-i18next';
 import LanguageSelector from '../components/LanguageSelector';
-import DirectLinkButton from '../components/DirectLinkButton';
 import { listOrders } from '../api/api';
 import RouteName from '../navigation/routes';
 
@@ -143,44 +142,6 @@ const ProfileScreen = ({ navigation, route }: any) => {
         </Card.Content>
       </Card>
 
-      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-        <Card.Content>
-          <Text style={[styles.sectionTitle, { color: theme.colors.onSurface }]}>
-            Прямые ссылки на страницы
-          </Text>
-          
-          <View style={styles.linksContainer}>
-            <DirectLinkButton
-              screenName={RouteName.CATALOG_SCREEN}
-              style={styles.linkButton}
-            >
-              {t('navigation.catalog')}
-            </DirectLinkButton>
-            
-            <DirectLinkButton
-              screenName={RouteName.CART_SCREEN}
-              style={styles.linkButton}
-            >
-              {t('navigation.cart')}
-            </DirectLinkButton>
-            
-            <DirectLinkButton
-              screenName={RouteName.ORDER_HISTORY_SCREEN}
-              style={styles.linkButton}
-              params={{ seatNumber }}
-            >
-              {t('navigation.orderHistory')}
-            </DirectLinkButton>
-            
-            <DirectLinkButton
-              screenName={RouteName.PAYMENT_SCREEN}
-              style={styles.linkButton}
-            >
-              {t('payment.title')}
-            </DirectLinkButton>
-          </View>
-        </Card.Content>
-      </Card>
 
       <Button
         mode="outlined"
@@ -217,16 +178,6 @@ const styles = StyleSheet.create({
   logoutButton: {
     margin: 16,
     marginTop: 0,
-  },
-  linksContainer: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    marginTop: 10,
-  },
-  linkButton: {
-    width: '48%',
-    marginBottom: 10,
   },
   badgeContainer: {
     justifyContent: 'center',


### PR DESCRIPTION
## Summary
- remove unused direct link buttons from the profile page
- add missing English translations for order history flow and navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f0fe4b4788331ba9f7af917dbfd6a