### PR TITLE
Enable order creation via payment screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -382,6 +382,7 @@ const RootStackNavigator = () => {
         name={RouteName.PAYMENT_SCREEN}
         component={PaymentScreen}
         options={{ title: t('payment.title') }}
+        initialParams={seatNumber ? { seatNumber } : undefined}
       />
       <Stack.Screen
         name={RouteName.ORDER_HISTORY_SCREEN}

--- a/frontend/src/screens/CartScreen.tsx
+++ b/frontend/src/screens/CartScreen.tsx
@@ -194,7 +194,14 @@ const CartScreen = ({ navigation, route }: any) => {
               </Text>
               <DirectLinkButton
                 screenName={RouteName.PAYMENT_SCREEN}
-                params={{ amount: calculateTotal().toString() }}
+                params={{
+                  amount: calculateTotal().toString(),
+                  seatNumber,
+                  items: cartItems.map((i) => ({
+                    item_id: Number(i.productId),
+                    quantity: i.quantity,
+                  })),
+                } as any}
                 style={styles.directLinkButton}
               >
                 {t('payment.payNow')} ({formatPrice(calculateTotal())})

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -126,7 +126,12 @@ const ProfileScreen = ({ navigation, route }: any) => {
             titleStyle={{ color: theme.colors.onSurface }}
             descriptionStyle={{ color: theme.colors.onSurfaceVariant }}
             left={props => <List.Icon {...props} icon="credit-card" color={theme.colors.primary} />}
-            onPress={() => navigation.navigate(RouteName.PAYMENT_SCREEN as never)}
+            onPress={() =>
+              navigation.navigate(
+                RouteName.PAYMENT_SCREEN as never,
+                { seatNumber, items: [] } as never
+              )
+            }
           />
           
           <Divider style={{ backgroundColor: theme.colors.outline }} />


### PR DESCRIPTION
## Summary
- extend route params for `PaymentScreen`
- create order on payment completion
- supply seat and items when navigating to `PaymentScreen`
- pass default seat as initial params

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1cbf70a08331b43b25e5ef51da42