### PR TITLE
Fix price param handling for payment

### DIFF
--- a/frontend/src/screens/CartScreen.tsx
+++ b/frontend/src/screens/CartScreen.tsx
@@ -195,7 +195,7 @@ const CartScreen = ({ navigation, route }: any) => {
               <DirectLinkButton
                 screenName={RouteName.PAYMENT_SCREEN}
                 params={{
-                  amount: calculateTotal().toString(),
+                  amount: calculateTotal(),
                   seatNumber,
                   items: cartItems.map((i) => ({
                     item_id: Number(i.productId),

--- a/frontend/src/screens/PaymentScreen.tsx
+++ b/frontend/src/screens/PaymentScreen.tsx
@@ -12,7 +12,7 @@ import { PaymentMethod } from '../types';
 interface PaymentScreenProps {
   route?: {
     params?: {
-      amount?: number;
+      amount?: number | string;
       seatNumber: string;
       items: { item_id: number; quantity: number }[];
     };
@@ -29,7 +29,10 @@ const PaymentScreen: React.FC<PaymentScreenProps> = ({ route }) => {
   const navigation = useNavigation();
   
   // Устанавливаем сумму по умолчанию, если она не была передана
-  const amount = route?.params?.amount || 1000;
+  const amount =
+    route?.params?.amount !== undefined
+      ? Number(route.params.amount)
+      : 1000;
   
   const handlePaymentComplete = async (paymentMethod: PaymentMethod) => {
     const params = route?.params;

--- a/frontend/src/utils/currency.ts
+++ b/frontend/src/utils/currency.ts
@@ -2,9 +2,10 @@ export const EXCHANGE_RATE = 80;
 
 import i18n from '../i18n/i18n';
 
-export const formatPrice = (price: number): string => {
+export const formatPrice = (price: number | string): string => {
+  const numPrice = typeof price === 'string' ? Number(price) : price;
   const lang = i18n.language;
-  const amount = lang === 'en' ? price / EXCHANGE_RATE : price;
+  const amount = lang === 'en' ? numPrice / EXCHANGE_RATE : numPrice;
   return `${amount.toFixed(2)} ${i18n.t('common.currency')}`;
 };
 


### PR DESCRIPTION
## Summary
- allow passing prices as strings when formatting
- parse numeric params for `PaymentScreen`
- pass raw total in cart direct link to `PaymentScreen`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f1f61e83c8331a00c8ea8233e17fa