### PR TITLE
Fix color parsing and improve cart add flow

### DIFF
--- a/frontend/src/screens/OrderHistoryScreen.tsx
+++ b/frontend/src/screens/OrderHistoryScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { Card, Text, Chip, Divider, Button, ActivityIndicator, useTheme } from 'react-native-paper';
 import { Order, OrderStatus } from '../types';
+import { addOpacity } from '../utils/color';
 import { useTranslation } from 'react-i18next';
 import { listOrders } from '../api/api';
 import RouteName from '../navigation/routes';
@@ -112,8 +113,8 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
           <Text style={[styles.orderId, { color: theme.colors.onSurface }]}>
             {t('orderStatus.orderNumber')} #{item.id}
           </Text>
-          <Chip 
-            style={{ backgroundColor: getStatusColor(item.status) + '20' }}
+          <Chip
+            style={{ backgroundColor: addOpacity(getStatusColor(item.status), 0.2) }}
             textStyle={{ color: getStatusColor(item.status) }}
           >
             {getStatusText(item.status)}
@@ -187,10 +188,10 @@ const OrderHistoryScreen = ({ navigation, route }: any) => {
             <Chip
               selected={selectedFilter === item.value}
               onPress={() => setSelectedFilter(item.value)}
-              style={[styles.filterChip, { 
-                backgroundColor: selectedFilter === item.value 
-                  ? theme.colors.primary + '20' 
-                  : theme.colors.surfaceVariant 
+              style={[styles.filterChip, {
+                backgroundColor: selectedFilter === item.value
+                  ? addOpacity(theme.colors.primary, 0.2)
+                  : theme.colors.surfaceVariant
               }]}
               textStyle={{ 
                 color: selectedFilter === item.value 

--- a/frontend/src/screens/ProductDetailsScreen.tsx
+++ b/frontend/src/screens/ProductDetailsScreen.tsx
@@ -11,6 +11,7 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
   const { product } = route.params;
   const [quantity, setQuantity] = useState(1);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
+  const [pendingItem, setPendingItem] = useState<OrderItem | null>(null);
   const { t } = useTranslation();
   const theme = useTheme();
 
@@ -23,9 +24,7 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
 
   const handleAddToCart = () => {
     // In a real app, this would dispatch to a cart state manager or context
-    // For now, we'll just show a snackbar
-    setSnackbarVisible(true);
-
+    // For now, we'll just show a snackbar and store the item temporarily
     const item: OrderItem = {
       productId: product.id,
       name: product.name,
@@ -34,10 +33,8 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
       image: product.image,
     };
 
-    // Navigate back to catalog after a short delay
-    setTimeout(() => {
-      navigation.navigate(RouteName.CART as never, { newItem: item } as never);
-    }, 1500);
+    setPendingItem(item);
+    setSnackbarVisible(true);
   };
 
   return (
@@ -188,18 +185,26 @@ const ProductDetailsScreen = ({ route, navigation }: any) => {
         duration={1500}
         action={{
           label: t('navigation.cart'),
-          onPress: () => navigation.navigate(RouteName.CART as never),
+          onPress: () => {
+            setSnackbarVisible(false);
+            if (pendingItem) {
+              navigation.navigate(RouteName.CART as never, { newItem: pendingItem } as never);
+              setPendingItem(null);
+            }
+          },
         }}
         style={{ backgroundColor: theme.colors.surfaceVariant }}
         theme={{
           colors: {
             accent: theme.colors.primary,
             surface: theme.colors.surfaceVariant,
-            onSurface: theme.colors.onSurfaceVariant
-          }
+            onSurface: theme.colors.onSurfaceVariant,
+          },
         }}
       >
-        {t('cart.added', { count: quantity })}
+        <Text style={{ color: theme.colors.onSurfaceVariant }}>
+          {t('cart.added', { count: quantity })}
+        </Text>
       </Snackbar>
     </ScrollView>
   );

--- a/frontend/src/utils/color.ts
+++ b/frontend/src/utils/color.ts
@@ -1,0 +1,20 @@
+export const addOpacity = (color: string, opacity: number): string => {
+  const clamp = Math.max(0, Math.min(opacity, 1));
+  if (color.startsWith('#')) {
+    let hex = color.slice(1);
+    if (hex.length === 3) {
+      hex = hex.split('').map((c) => c + c).join('');
+    }
+    const alpha = Math.round(clamp * 255).toString(16).padStart(2, '0');
+    return `#${hex}${alpha}`;
+  }
+  const rgbMatch = color.match(/rgba?\(([^)]+)\)/);
+  if (rgbMatch) {
+    const [r, g, b] = rgbMatch[1]
+      .split(',')
+      .slice(0, 3)
+      .map((v) => parseInt(v.trim(), 10));
+    return `rgba(${r}, ${g}, ${b}, ${clamp})`;
+  }
+  return color;
+};


### PR DESCRIPTION
## Summary
- fix invalid color strings by adding `addOpacity` helper
- use `addOpacity` in OrderHistoryScreen
- store pending cart item and only navigate to cart when snackbar action pressed
- show legible snackbar text when adding items to cart

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f25b8c4688331887c6fcc7f967582