### PR TITLE
Add light blue theme tokens

### DIFF
--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -49,6 +49,15 @@ const lightThemeColors = {
   onPrimary: '#000000',
   primaryContainer: '#E3F2FD',
   onPrimaryContainer: '#001E2F',
+  // Use lighter blues for chip backgrounds and other secondary accents
+  secondary: '#64B5F6',
+  onSecondary: '#000000',
+  secondaryContainer: '#D8EAFE',
+  onSecondaryContainer: '#001E2F',
+  tertiary: '#42A5F5',
+  onTertiary: '#FFFFFF',
+  tertiaryContainer: '#D2E4FF',
+  onTertiaryContainer: '#001E2F',
 };
 
 // Configure font styles


### PR DESCRIPTION
## Summary
- extend light theme colors with custom secondary and tertiary tokens

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554598d6648331974381bc8cda7909