### PR TITLE
Fix login error handling and localization

### DIFF
--- a/airservice/api/auth.py
+++ b/airservice/api/auth.py
@@ -1,5 +1,8 @@
 from flask import Blueprint, request, jsonify, abort
 from werkzeug.security import check_password_hash
+from flask_babel import gettext
+from marshmallow import ValidationError
+from marshmallow.validate import Email
 
 from ..models import User
 
@@ -13,7 +16,12 @@ def login():
     password = data.get('password')
     if not email or not password:
         abort(400)
+
+    try:
+        Email()(email)
+    except ValidationError:
+        return jsonify({'error': gettext('Invalid email')}), 400
     user = User.query.filter_by(email=email).first()
     if not user or not check_password_hash(user.password_hash, password):
-        abort(401)
+        return jsonify({'error': gettext('Invalid credentials')}), 401
     return jsonify({'seat': user.seat, 'is_admin': user.is_admin})

--- a/airservice/translations/en/LC_MESSAGES/messages.po
+++ b/airservice/translations/en/LC_MESSAGES/messages.po
@@ -35,3 +35,11 @@ msgstr "Invalid payload"
 msgid "Invalid item IDs: %(ids)s"
 msgstr "Invalid item IDs: %(ids)s"
 
+#: airservice/api/auth.py
+msgid "Invalid credentials"
+msgstr "Invalid credentials"
+
+#: airservice/api/auth.py
+msgid "Invalid email"
+msgstr "Invalid email"
+

--- a/airservice/translations/ru/LC_MESSAGES/messages.po
+++ b/airservice/translations/ru/LC_MESSAGES/messages.po
@@ -36,3 +36,11 @@ msgstr "Неверные данные"
 msgid "Invalid item IDs: %(ids)s"
 msgstr "Неверные ID товаров: %(ids)s"
 
+#: airservice/api/auth.py
+msgid "Invalid credentials"
+msgstr "Неверные учетные данные"
+
+#: airservice/api/auth.py
+msgid "Invalid email"
+msgstr "Неверный формат электронной почты"
+

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -6,7 +6,13 @@ const API_URL = Constants.expoConfig?.extra?.apiUrl as string;
 
 async function handleResponse(res: Response) {
   if (!res.ok) {
-    const text = await res.text().catch(() => '');
+    let text = await res.text().catch(() => '');
+    try {
+      const data = JSON.parse(text);
+      text = data.error || data.message || text;
+    } catch {
+      // keep raw text
+    }
     throw new Error(text || `Request failed with status ${res.status}`);
   }
   return res.json();

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -32,6 +32,7 @@ export default {
     total: 'Total',
     currency: '$',
     all: 'All',
+    appName: 'Air Service',
   },
 
   // Navigation
@@ -59,6 +60,7 @@ export default {
     enterSeatNumber: 'Enter seat number',
     seatNumber: 'Seat number',
     invalidCredentials: 'Invalid credentials',
+    invalidEmail: 'Invalid email format',
     emailRequired: 'Email is required',
     passwordRequired: 'Password is required',
     seatRequired: 'Seat number is required',

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -32,6 +32,7 @@ export default {
     total: 'Итого',
     currency: '₽',
     all: 'Все',
+    appName: 'Авиа-Сервис',
   },
 
   // Навигация
@@ -59,6 +60,7 @@ export default {
     enterSeatNumber: 'Введите номер места',
     seatNumber: 'Номер места',
     invalidCredentials: 'Неверные учетные данные',
+    invalidEmail: 'Неверный формат электронной почты',
     emailRequired: 'Введите электронную почту',
     passwordRequired: 'Введите пароль',
     seatRequired: 'Введите номер места',

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -35,6 +35,13 @@ const LoginScreen = ({ navigation, route }: LoginScreenProps) => {
           return;
         }
 
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+          setError(t('auth.invalidEmail'));
+          setLoading(false);
+          return;
+        }
+
         if (!password) {
           setError(t('auth.passwordRequired'));
           setLoading(false);
@@ -74,7 +81,9 @@ const LoginScreen = ({ navigation, route }: LoginScreenProps) => {
           source={{ uri: require('../assets/air_service.jpg') }}
           style={styles.logo}
         />
-        <Text style={[styles.title, { color: theme.colors.onBackground }]}>Авиа-Сервис</Text>
+        <Text style={[styles.title, { color: theme.colors.onBackground }]}>
+          {t('common.appName')}
+        </Text>
       </View>
       
       {!isGuestMode ? (

--- a/messages.pot
+++ b/messages.pot
@@ -34,3 +34,11 @@ msgstr ""
 msgid "Invalid item IDs: %(ids)s"
 msgstr ""
 
+#: airservice/api/auth.py
+msgid "Invalid credentials"
+msgstr ""
+
+#: airservice/api/auth.py
+msgid "Invalid email"
+msgstr ""
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -40,3 +40,32 @@ def test_login_and_order_uses_account_seat(client, app, sample_data):
     rv = client.get(f"/orders/{order_id}")
     assert rv.status_code == 200
     assert rv.get_json()["seat"] == "12A"
+
+
+def test_login_invalid_email_format(client):
+    rv = client.post(
+        "/auth/login",
+        json={"email": "bad_email", "password": "x"},
+        headers={"Accept-Language": "ru"},
+    )
+    assert rv.status_code == 400
+    assert rv.get_json()["error"] == "Неверный формат электронной почты"
+
+
+def test_login_wrong_credentials(client, app):
+    with app.app_context():
+        user = User(
+            email="demo@example.com",
+            password_hash=generate_password_hash("secret"),
+            seat="1A",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+    rv = client.post(
+        "/auth/login",
+        json={"email": "demo@example.com", "password": "bad"},
+        headers={"Accept-Language": "en"},
+    )
+    assert rv.status_code == 401
+    assert rv.get_json()["error"] == "Invalid credentials"


### PR DESCRIPTION
## Summary
- validate email format on login
- return localized error messages from login API
- display translated application name
- handle JSON errors in frontend API client
- support invalid email message translations
- add tests for login failures

## Testing
- `pybabel compile -d airservice/translations`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685751b4747c8331a6460a3997dbeaf6