### PR TITLE
Fix login localization

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -13,7 +13,9 @@ async function handleResponse(res: Response) {
     } catch {
       // keep raw text
     }
-    throw new Error(text || `Request failed with status ${res.status}`);
+    const err = new Error(text || `Request failed with status ${res.status}`) as Error & { status?: number };
+    err.status = res.status;
+    throw err;
   }
   return res.json();
 }

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -63,7 +63,13 @@ const LoginScreen = ({ navigation, route }: LoginScreenProps) => {
         route.params.onLogin(false, seatNumber);
       }
     } catch (err: any) {
-      setError(err.message || t('auth.invalidCredentials'));
+      if (err.status === 401) {
+        setError(t('auth.invalidCredentials'));
+      } else if (err.status === 400) {
+        setError(t('auth.invalidEmail'));
+      } else {
+        setError(err.message || t('auth.invalidCredentials'));
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- attach status to API errors
- show localized login error messages based on status

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857580cb2ac833183a1d85fd0e26fb8